### PR TITLE
P2P Sidecar syncing

### DIFF
--- a/beacon-chain/db/kv/blobs.go
+++ b/beacon-chain/db/kv/blobs.go
@@ -13,8 +13,9 @@ import (
 
 // SaveBlobsSidecar saves the blobs for a given epoch in the sidecar bucket.
 func (s *Store) SaveBlobsSidecar(ctx context.Context, blob *ethpb.BlobsSidecar) error {
-	_, span := trace.StartSpan(ctx, "BeaconDB.SaveBlobsSidecar")
+	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveBlobsSidecar")
 	defer span.End()
+
 	return s.db.Update(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(blobsBucket)
 		enc, err := encode(ctx, blob)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -167,10 +167,9 @@ func (vs *Server) proposeGenericBeaconBlock(ctx context.Context, blk interfaces.
 	}
 	if sidecar != nil {
 		// TODO(inphi): We may want to broadcast blobs at best-effort.
-		// TODO(inphi): Uncomment this once P2P is working again
-		//if err := vs.P2P.Broadcast(ctx, sidecar); err != nil {
-		//return nil, fmt.Errorf("could not broadcast blobs sidecar: %v", err)
-		//}
+		if err := vs.P2P.Broadcast(ctx, sidecar); err != nil {
+			return nil, fmt.Errorf("could not broadcast blobs sidecar: %v", err)
+		}
 	}
 
 	log.WithFields(logrus.Fields{

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -167,9 +167,14 @@ func (vs *Server) proposeGenericBeaconBlock(ctx context.Context, blk interfaces.
 	}
 	if sidecar != nil {
 		// TODO(inphi): We may want to broadcast blobs at best-effort.
-		if err := vs.P2P.Broadcast(ctx, sidecar); err != nil {
-			return nil, fmt.Errorf("could not broadcast blobs sidecar: %v", err)
-		}
+		go func() {
+			// HACK: Broadcast sidecars after a delay to give the network
+			// time to accept the prior beacon block broadcast needed to validate sidecars
+			time.Sleep(time.Second * 3)
+			if err := vs.P2P.Broadcast(ctx, sidecar); err != nil {
+				log.Errorf("could not broadcast blobs sidecar: %v", err)
+			}
+		}()
 	}
 
 	log.WithFields(logrus.Fields{

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "subscriber_handlers.go",
         "subscriber_sync_committee_message.go",
         "subscriber_sync_contribution_proof.go",
+        "subscriber_blobs_sidecar.go",
         "subscription_topic_handler.go",
         "utils.go",
         "validate_aggregate_proof.go",
@@ -45,6 +46,7 @@ go_library(
         "validate_sync_committee_message.go",
         "validate_sync_contribution_proof.go",
         "validate_voluntary_exit.go",
+        "validate_blobs_sidecar.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/sync",
     visibility = [

--- a/beacon-chain/sync/fork_watcher.go
+++ b/beacon-chain/sync/fork_watcher.go
@@ -78,7 +78,7 @@ func (s *Service) registerForUpcomingFork(currEpoch types.Epoch) error {
 				return nil
 			}
 			s.registerSubscribers(nextEpoch, digest)
-			// TODO(inphi): Register new RPC handlers for blob side cars.
+			s.registerRPCHandlersEIP4844()
 		}
 	}
 	return nil

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -51,6 +51,7 @@ const seenExitSize = 100
 const seenProposerSlashingSize = 100
 const badBlockSize = 1000
 const syncMetricsInterval = 10 * time.Second
+const seenBlobsSidecarSize = 1000
 
 var (
 	// Seconds in one epoch.
@@ -134,6 +135,8 @@ type Service struct {
 	badBlockLock                     sync.RWMutex
 	syncContributionBitsOverlapLock  sync.RWMutex
 	syncContributionBitsOverlapCache *lru.Cache
+	seenBlobsSidecarLock             sync.RWMutex
+	seenBlobsSidecarCache            *lru.Cache
 	signatureChan                    chan *signatureVerifier
 }
 
@@ -228,6 +231,7 @@ func (s *Service) initCaches() {
 	s.seenAttesterSlashingCache = make(map[uint64]bool)
 	s.seenProposerSlashingCache = lruwrpr.New(seenProposerSlashingSize)
 	s.badBlockCache = lruwrpr.New(badBlockSize)
+	s.seenBlobsSidecarCache = lruwrpr.New(seenBlobsSidecarSize)
 }
 
 func (s *Service) registerHandlers() {

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -118,6 +118,15 @@ func (s *Service) registerSubscribers(epoch types.Epoch, digest [4]byte) {
 			)
 		}
 	}
+	// EIP-4844 Fork Version
+	if epoch >= params.BeaconConfig().Eip4844ForkEpoch {
+		s.subscribe(
+			p2p.BlobsSubnetTopicFormat,
+			s.validateBlobsSidecar,
+			s.blobsSidecarSubscriber,
+			digest,
+		)
+	}
 }
 
 // subscribe to a given topic with a given validator and subscription handler.

--- a/beacon-chain/sync/subscriber_blobs_sidecar.go
+++ b/beacon-chain/sync/subscriber_blobs_sidecar.go
@@ -1,0 +1,24 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
+	"google.golang.org/protobuf/proto"
+)
+
+func (s *Service) blobsSidecarSubscriber(ctx context.Context, msg proto.Message) error {
+	m, ok := msg.(*ethpb.SignedBlobsSidecar)
+	if !ok {
+		return fmt.Errorf("message was not type *eth.SignedBlobsSidecar, type=%T", msg)
+	}
+
+	if m == nil {
+		return errors.New("nil blobs sidecar message")
+	}
+
+	blob := m.Message
+	return s.cfg.beaconDB.SaveBlobsSidecar(ctx, blob)
+}

--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -255,6 +255,11 @@ func (s *Service) validateBeaconBlock(ctx context.Context, blk interfaces.Signed
 		s.setBadBlock(ctx, blockRoot)
 		return err
 	}
+
+	if err = s.validateEip4844BeaconBlock(ctx, parentState, blk.Block()); err != nil {
+		s.setBadBlock(ctx, blockRoot)
+		return err
+	}
 	return nil
 }
 
@@ -363,6 +368,44 @@ func (s *Service) validateBellatrixBeaconBlock(ctx context.Context, parentState 
 		return ErrOptimisticParent
 	}
 	return nil
+}
+
+// validateEip4844BeaconBlock validates the block for the EIP4844 fork.
+// spec code:
+//   [REJECT] The KZG commitments of the blobs are all correctly encoded compressed BLS G1 Points.
+//   i.e. `all(bls.KeyValidate(commitment) for commitment in block.body.blob_kzgs)`
+//   [REJECT] The KZG commitments correspond to the versioned hashes in the transactions list.
+//   i.e. `verify_kzgs_against_transactions(block.body.execution_payload.transactions, block.body.blob_kzgs)`
+func (s *Service) validateEip4844BeaconBlock(ctx context.Context, parentState state.BeaconState, blk interfaces.BeaconBlock) error {
+	// Error if block and state are not the same version
+	if parentState.Version() != blk.Version() {
+		return errors.New("block and state are not the same version")
+	}
+
+	body := blk.Body()
+	payload, err := body.ExecutionPayload()
+	if err != nil {
+		return err
+	}
+	if payload == nil {
+		return errors.New("execution payload is nil")
+	}
+
+	blobKzgs, err := body.BlobKzgs()
+	if err != nil {
+		return err
+	}
+	blobKzgsInput := make([][48]byte, len(blobKzgs))
+	for i := range blobKzgs {
+		if len(blobKzgs[i]) != 48 {
+			return errors.New("invalid kzg encoding")
+		}
+		if _, err := bls.FromCompressedG1(blobKzgs[i]); err != nil {
+			return errors.Wrap(err, "invalid commitment")
+		}
+		blobKzgsInput[i] = bytesutil.ToBytes48(blobKzgs[i])
+	}
+	return eip4844.VerifyKzgsAgainstTxs(payload.Transactions, blobKzgsInput)
 }
 
 // Returns true if the block is not the first block proposed for the proposer for the slot.

--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -255,11 +255,6 @@ func (s *Service) validateBeaconBlock(ctx context.Context, blk interfaces.Signed
 		s.setBadBlock(ctx, blockRoot)
 		return err
 	}
-
-	if err = s.validateEip4844BeaconBlock(ctx, parentState, blk.Block()); err != nil {
-		s.setBadBlock(ctx, blockRoot)
-		return err
-	}
 	return nil
 }
 
@@ -368,44 +363,6 @@ func (s *Service) validateBellatrixBeaconBlock(ctx context.Context, parentState 
 		return ErrOptimisticParent
 	}
 	return nil
-}
-
-// validateEip4844BeaconBlock validates the block for the EIP4844 fork.
-// spec code:
-//   [REJECT] The KZG commitments of the blobs are all correctly encoded compressed BLS G1 Points.
-//   i.e. `all(bls.KeyValidate(commitment) for commitment in block.body.blob_kzgs)`
-//   [REJECT] The KZG commitments correspond to the versioned hashes in the transactions list.
-//   i.e. `verify_kzgs_against_transactions(block.body.execution_payload.transactions, block.body.blob_kzgs)`
-func (s *Service) validateEip4844BeaconBlock(ctx context.Context, parentState state.BeaconState, blk interfaces.BeaconBlock) error {
-	// Error if block and state are not the same version
-	if parentState.Version() != blk.Version() {
-		return errors.New("block and state are not the same version")
-	}
-
-	body := blk.Body()
-	payload, err := body.ExecutionPayload()
-	if err != nil {
-		return err
-	}
-	if payload == nil {
-		return errors.New("execution payload is nil")
-	}
-
-	blobKzgs, err := body.BlobKzgs()
-	if err != nil {
-		return err
-	}
-	blobKzgsInput := make([][48]byte, len(blobKzgs))
-	for i := range blobKzgs {
-		if len(blobKzgs[i]) != 48 {
-			return errors.New("invalid kzg encoding")
-		}
-		if _, err := bls.FromCompressedG1(blobKzgs[i]); err != nil {
-			return errors.Wrap(err, "invalid commitment")
-		}
-		blobKzgsInput[i] = bytesutil.ToBytes48(blobKzgs[i])
-	}
-	return eip4844.VerifyKzgsAgainstTxs(payload.Transactions, blobKzgsInput)
 }
 
 // Returns true if the block is not the first block proposed for the proposer for the slot.

--- a/beacon-chain/sync/validate_blobs_sidecar.go
+++ b/beacon-chain/sync/validate_blobs_sidecar.go
@@ -1,0 +1,164 @@
+package sync
+
+import (
+	"context"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/pkg/errors"
+	kbls "github.com/protolambda/go-kzg/bls"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/altair"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/signing"
+	"github.com/prysmaticlabs/prysm/config/params"
+	"github.com/prysmaticlabs/prysm/consensus-types/interfaces"
+	types "github.com/prysmaticlabs/prysm/consensus-types/primitives"
+	"github.com/prysmaticlabs/prysm/crypto/bls"
+	"github.com/prysmaticlabs/prysm/encoding/bytesutil"
+	"github.com/prysmaticlabs/prysm/monitoring/tracing"
+	"github.com/prysmaticlabs/prysm/network/forks"
+	enginev1 "github.com/prysmaticlabs/prysm/proto/engine/v1"
+	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/time/slots"
+	"go.opencensus.io/trace"
+)
+
+// Gossip Validation Conditions:
+// [IGNORE] the sidecar.beacon_block_slot is for the current slot (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
+//  -- i.e. blobs_sidecar.beacon_block_slot == current_slot.
+// [REJECT] the sidecar.blobs are all well formatted, i.e. the BLSFieldElement in valid range (x < BLS_MODULUS).
+// [REJECT] the beacon proposer signature, signed_blobs_sidecar.signature, is valid
+// [IGNORE] The sidecar is the first sidecar with valid signature received for the (proposer_index, sidecar.beacon_block_slot)
+// combination, where proposer_index is the validator index of the beacon block proposer of blobs_sidecar.beacon_block_slot
+func (s *Service) validateBlobsSidecar(ctx context.Context, pid peer.ID, msg *pubsub.Message) (pubsub.ValidationResult, error) {
+	ctx, span := trace.StartSpan(ctx, "sync.validateBlobsSidecar")
+	defer span.End()
+
+	// Accept the blob if it came from itself.
+	if pid == s.cfg.p2p.PeerID() {
+		return pubsub.ValidationAccept, nil
+	}
+
+	// Ignore the blobs sidecar if the beacon node is syncing.
+	if s.cfg.initialSync.Syncing() {
+		return pubsub.ValidationIgnore, nil
+	}
+
+	// TODO(inphi): Handle received blobs when optimistic.
+
+	m, err := s.decodePubsubMessage(msg)
+	if err != nil {
+		tracing.AnnotateError(span, err)
+		return pubsub.ValidationReject, errors.Wrap(err, "Could not decode message")
+	}
+
+	signed, ok := m.(*ethpb.SignedBlobsSidecar)
+	if !ok {
+		return pubsub.ValidationReject, errWrongMessage
+	}
+	if signed.Message == nil {
+		return pubsub.ValidationReject, errors.New("nil blob message")
+	}
+	if signed.Signature == nil {
+		return pubsub.ValidationReject, errors.New("nil blob signature")
+	}
+
+	if err := altair.ValidateSyncMessageTime(signed.Message.GetBeaconBlockSlot(), s.cfg.chain.GenesisTime(), params.BeaconNetworkConfig().MaximumGossipClockDisparity); err != nil {
+		tracing.AnnotateError(span, err)
+		return pubsub.ValidationIgnore, err
+	}
+
+	blobs := signed.Message.GetBlobs()
+	if err := validateBlobFr(blobs); err != nil {
+		return pubsub.ValidationReject, err
+	}
+
+	blk, err := s.cfg.beaconDB.Block(ctx, bytesutil.ToBytes32(signed.Message.BeaconBlockRoot))
+	if err != nil {
+		return pubsub.ValidationIgnore, errors.Wrap(err, "Could not retrieve block")
+	}
+
+	validationResult, err := s.validateBlobsSidecarSignature(ctx, blk, signed)
+	if err != nil {
+		tracing.AnnotateError(span, err)
+		return validationResult, err
+	}
+
+	if s.hasSeenBlobsSidecarIndexSlot(blk.Block().ProposerIndex(), signed.Message.BeaconBlockSlot) {
+		return pubsub.ValidationIgnore, nil
+	}
+
+	s.setBlobsSidecarIndexSlotSeen(blk.Block().ProposerIndex(), signed.Message.BeaconBlockSlot)
+	msg.ValidatorData = signed
+
+	return pubsub.ValidationAccept, nil
+}
+
+func (s *Service) validateBlobsSidecarSignature(ctx context.Context, blk interfaces.SignedBeaconBlock, m *ethpb.SignedBlobsSidecar) (pubsub.ValidationResult, error) {
+	currentEpoch := slots.ToEpoch(m.Message.BeaconBlockSlot)
+	fork, err := forks.Fork(currentEpoch)
+	if err != nil {
+		return pubsub.ValidationIgnore, err
+	}
+	state, err := s.cfg.stateGen.StateByRoot(ctx, bytesutil.ToBytes32(m.Message.BeaconBlockRoot))
+	if err != nil {
+		return pubsub.ValidationIgnore, err
+	}
+	proposer, err := state.ValidatorAtIndex(blk.Block().ProposerIndex())
+	if err != nil {
+		return pubsub.ValidationIgnore, err
+	}
+	proposerPubKey := proposer.PublicKey
+	blobSigning := &ethpb.BlobsSidecar{
+		BeaconBlockRoot: m.Message.BeaconBlockRoot,
+		BeaconBlockSlot: m.Message.BeaconBlockSlot,
+		Blobs:           m.Message.Blobs,
+	}
+
+	domain, err := signing.Domain(fork, currentEpoch, params.BeaconConfig().DomainBlobsSidecar, state.GenesisValidatorsRoot())
+	if err != nil {
+		return pubsub.ValidationReject, err
+	}
+	pKey, err := bls.PublicKeyFromBytes(proposerPubKey[:])
+	sigRoot, err := signing.ComputeSigningRoot(blobSigning, domain)
+	if err != nil {
+		return pubsub.ValidationReject, err
+	}
+
+	set := &bls.SignatureBatch{
+		Messages:   [][32]byte{sigRoot},
+		PublicKeys: []bls.PublicKey{pKey},
+		Signatures: [][]byte{m.Signature},
+	}
+	return s.validateWithBatchVerifier(ctx, "blobs sidecar signature", set)
+}
+
+func validateBlobFr(blobs []*enginev1.Blob) error {
+	for _, blob := range blobs {
+		for _, b := range blob.Blob {
+			if len(b) != 32 {
+				return errors.New("invalid blob field element size")
+			}
+			if !kbls.ValidFr(bytesutil.ToBytes32(b)) {
+				return errors.New("invalid blob field element")
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Service) hasSeenBlobsSidecarIndexSlot(proposerIndex types.ValidatorIndex, slot types.Slot) bool {
+	s.seenBlobsSidecarLock.RLock()
+	defer s.seenBlobsSidecarLock.RUnlock()
+
+	b := append(bytesutil.Bytes32(uint64(proposerIndex)), bytesutil.Bytes32(uint64(slot))...)
+	_, seen := s.seenBlobsSidecarCache.Get(string(b))
+	return seen
+}
+
+func (s *Service) setBlobsSidecarIndexSlotSeen(proposerIndex types.ValidatorIndex, slot types.Slot) {
+	s.seenBlobsSidecarLock.RLock()
+	defer s.seenBlobsSidecarLock.RUnlock()
+
+	b := append(bytesutil.Bytes32(uint64(proposerIndex)), bytesutil.Bytes32(uint64(slot))...)
+	s.seenBlobsSidecarCache.Add(string(b), true)
+}


### PR DESCRIPTION
- Gossip blob sidecars over the net

NOTE: Syncing blobs from genesis (initial-sync) doesn't work yet. This change only allows beacon nodes to synchronized broadcast blob sidecars.