### PR TITLE
Replace Prysm's evaluate_polynomial_in_evaluation_form with Geth's

### DIFF
--- a/beacon-chain/core/blob/sidecar.go
+++ b/beacon-chain/core/blob/sidecar.go
@@ -203,6 +203,8 @@ func blsModInv(out *big.Int, x *big.Int) {
 // Evaluate a polynomial (in evaluation form) at an arbitrary point `x`
 // Uses the barycentric formula:
 // 	 f(x) = (1 - x**WIDTH) / WIDTH  *  sum_(i=0)^WIDTH  (f(DOMAIN[i]) * DOMAIN[i]) / (x - DOMAIN[i])
+// TODO: Rather than duplicate this function in Geth and Prysm, it should be moved to
+// a lower-level library like go-kzg.
 func EvaluatePolyInEvaluationForm(yFr *bls.Fr, poly []bls.Fr, x *bls.Fr) {
 	if len(poly) != params.FieldElementsPerBlob {
 		panic("invalid polynomial length")

--- a/beacon-chain/core/blob/sidecar.go
+++ b/beacon-chain/core/blob/sidecar.go
@@ -27,7 +27,7 @@ func init() {
 	// publicly exposed there.
 	blsModulus.SetString("52435875175126190479447740508185965837690552500527637822603658699938581184513", 10)
 
-	// Initialize rootsOfUnity which are used by evaluatePolynomialInEvaluationForm
+	// Initialize rootsOfUnity which are used by EvaluatePolyInEvaluationForm
 	var one big.Int
 	one.SetInt64(1)
 	var length big.Int
@@ -105,10 +105,10 @@ func ValidateBlobsSidecar(slot types.Slot, root [32]byte, commitments [][]byte, 
 		return err
 	}
 
-	y := evaluatePolynomialInEvaluationForm(aggregatedPoly, &x)
+	var y bls.Fr
+	EvaluatePolyInEvaluationForm(&y, aggregatedPoly, &x)
 
-	var yFr bls.Fr
-	b, err := verifyKZGProof(aggregatedPolyCommitment, &x, bigToFr(&yFr, y), sidecar.AggregatedProof)
+	b, err := verifyKZGProof(aggregatedPolyCommitment, &x, &y, sidecar.AggregatedProof)
 	if err != nil {
 		return err
 	}
@@ -194,29 +194,58 @@ func vectorLinComb(blobs []*v1.Blob, scalars []bls.Fr) ([]bls.Fr, error) {
 	return r, nil
 }
 
-// evaluatePolynomialInEvaluationForm implement the function evaluate_polynomial_in_evaluation_form
-// from the EIP-4844 spec
-func evaluatePolynomialInEvaluationForm(poly []bls.Fr, x *bls.Fr) *big.Int {
-	var tmp, tmpSub, r bls.Fr
-	for i := 0; i < params.FieldElementsPerBlob; i++ {
-		bls.SubModFr(&tmpSub, x, &rootsOfUnity[i])
-		bls.MulModFr(&tmp, &poly[i], &rootsOfUnity[i])
-		bls.DivModFr(&tmp, &tmp, &tmpSub)
-		bls.AddModFr(&r, &r, &tmp)
+func blsModInv(out *big.Int, x *big.Int) {
+	if len(x.Bits()) != 0 { // if non-zero
+		out.ModInverse(x, &blsModulus)
 	}
-	// seems PowModInv() isn't implemented in go-kzg except for the pure bignum impl so we have
-	// to convert to bigint here for the final computation. TODO: add this to go-kzg
-	var yChallenge, width, inv, t, xc big.Int
-	width.SetInt64(params.FieldElementsPerBlob)
-	inv.ModInverse(&width, &blsModulus)
-	frToBig(&xc, x)
-	frToBig(&yChallenge, &r)
-	t.Exp(&xc, &width, &blsModulus).
-		Sub(&t, big.NewInt(1)).
-		Mul(&t, &inv)
-	yChallenge.Mul(&yChallenge, &t).
-		Mod(&yChallenge, &blsModulus)
-	return &yChallenge
+}
+
+// Evaluate a polynomial (in evaluation form) at an arbitrary point `x`
+// Uses the barycentric formula:
+// 	 f(x) = (1 - x**WIDTH) / WIDTH  *  sum_(i=0)^WIDTH  (f(DOMAIN[i]) * DOMAIN[i]) / (x - DOMAIN[i])
+func EvaluatePolyInEvaluationForm(yFr *bls.Fr, poly []bls.Fr, x *bls.Fr) {
+	if len(poly) != params.FieldElementsPerBlob {
+		panic("invalid polynomial length")
+	}
+
+	width := big.NewInt(int64(params.FieldElementsPerBlob))
+	var inverseWidth big.Int
+	blsModInv(&inverseWidth, width)
+
+	// Precomputing the mod inverses as a batch is alot faster
+	invDenom := make([]bls.Fr, params.FieldElementsPerBlob)
+	for i := range invDenom {
+		bls.SubModFr(&invDenom[i], x, &rootsOfUnity[i])
+	}
+	bls.BatchInvModFr(invDenom)
+
+	var y bls.Fr
+	for i := 0; i < params.FieldElementsPerBlob; i++ {
+		var num bls.Fr
+		bls.MulModFr(&num, &poly[i], &rootsOfUnity[i])
+
+		var denom bls.Fr
+		bls.SubModFr(&denom, x, &rootsOfUnity[i])
+
+		var div bls.Fr
+		bls.MulModFr(&div, &num, &invDenom[i])
+
+		var tmp bls.Fr
+		bls.AddModFr(&tmp, &y, &div)
+		bls.CopyFr(&y, &tmp)
+	}
+
+	xB := new(big.Int)
+	frToBig(xB, x)
+	powB := new(big.Int).Exp(xB, width, &blsModulus)
+	powB.Sub(powB, big.NewInt(1))
+
+	// TODO: add ExpModFr to go-kzg
+	var yB big.Int
+	frToBig(&yB, &y)
+	yB.Mul(&yB, new(big.Int).Mul(powB, &inverseWidth))
+	yB.Mod(&yB, &blsModulus)
+	bls.SetFr(yFr, yB.String())
 }
 
 // verifyKZGProof implements verify_kzg_proof from the EIP-4844 spec

--- a/go.mod
+++ b/go.mod
@@ -255,7 +255,7 @@ require (
 	github.com/peterh/liner v1.2.0 // indirect
 	github.com/prometheus/tsdb v0.10.0 // indirect
 	github.com/prysmaticlabs/gohashtree v0.0.1-alpha.0.20220303211031-f753e083138c
-	golang.org/x/sys v0.0.0-20220702020025-31831981b65f // indirect
+	golang.org/x/sys v0.0.0-20220818161305-2296e01440c6 // indirect
 	google.golang.org/api v0.34.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	k8s.io/klog/v2 v2.3.0 // indirect
@@ -271,3 +271,9 @@ replace github.com/ferranbt/fastssz => github.com/prysmaticlabs/fastssz v0.0.0-2
 
 // For eip-4844 types
 replace github.com/ethereum/go-ethereum => github.com/mdehoog/go-ethereum v1.10.19-0.20220719053341-c76d2bd57d77
+
+// For BatchInvModFr
+replace github.com/protolambda/go-kzg => github.com/Inphi/go-kzg v0.0.0-20220819034031-381084440411
+
+// For Inphi/go-kzg's bls12381.RedInverseBatchFr
+replace github.com/kilic/bls12-381 => github.com/Inphi/bls12-381 v0.0.0-20220819032644-3ae7bcd28efc

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,10 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/Inphi/bls12-381 v0.0.0-20220819032644-3ae7bcd28efc h1:dO3UA5UAc0KSHVgWNJTtG3PQwmFqlL6lJatg/9tvc38=
+github.com/Inphi/bls12-381 v0.0.0-20220819032644-3ae7bcd28efc/go.mod h1:tlkavyke+Ac7h8R3gZIjI5LKBcvMlSWnXNMgT3vZXo8=
+github.com/Inphi/go-kzg v0.0.0-20220819034031-381084440411 h1:UPONzX5HWFya8T/r8WYlbiyl1/sTwiPLsVh8NjJY7to=
+github.com/Inphi/go-kzg v0.0.0-20220819034031-381084440411/go.mod h1:sy8rQ8S75AAFdRj1QkEGm8kuSrfMa5YEDhbJ7V+nwrI=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MariusVanDerWijden/FuzzyVM v0.0.0-20210904205340-da82a0d3e27a/go.mod h1:iKT2vQyFJT+f8rXja6l58k8hv0gLvNx9C23FITcSP8E=
 github.com/MariusVanDerWijden/FuzzyVM v0.0.0-20220304110512-764253afa8c2 h1:HKOeocqWNWitsHPVPdCUJRalFmDNVHs2xTKmse4svwU=
@@ -654,8 +658,6 @@ github.com/karalabe/usb v0.0.2 h1:M6QQBNxF+CQ8OFvxrT90BA0qBOXymndZnk5q235mFc4=
 github.com/karalabe/usb v0.0.2/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/kevinms/leakybucket-go v0.0.0-20200115003610-082473db97ca h1:qNtd6alRqd3qOdPrKXMZImV192ngQ0WSh1briEO33Tk=
 github.com/kevinms/leakybucket-go v0.0.0-20200115003610-082473db97ca/go.mod h1:ph+C5vpnCcQvKBwJwKLTK3JLNGnBXYlG7m7JjoC/zYA=
-github.com/kilic/bls12-381 v0.1.1-0.20210208205449-6045b0235e36 h1:ac3KEjgHrX671Q7gW6aGmiQcDrYzmwrdq76HElwyewA=
-github.com/kilic/bls12-381 v0.1.1-0.20210208205449-6045b0235e36/go.mod h1:tlkavyke+Ac7h8R3gZIjI5LKBcvMlSWnXNMgT3vZXo8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -1118,8 +1120,6 @@ github.com/prometheus/prom2json v1.3.0/go.mod h1:rMN7m0ApCowcoDlypBHlkNbp5eJQf/+
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/prometheus/tsdb v0.10.0 h1:If5rVCMTp6W2SiRAQFlbpJNgVlgMEd+U2GZckwK38ic=
 github.com/prometheus/tsdb v0.10.0/go.mod h1:oi49uRhEe9dPUTlS3JRZOwJuVi6tmh10QSgwXEyGCt4=
-github.com/protolambda/go-kzg v0.0.0-20220220065500-36404333406f h1:lkbqhxyUcDtzxqylImpylMUCkigRLQ4791yn6OLy2/g=
-github.com/protolambda/go-kzg v0.0.0-20220220065500-36404333406f/go.mod h1:P9wXBp1WMjLHx2C22Gg7FyqQcJktMAohrKj3tdaWIH0=
 github.com/protolambda/ztyp v0.2.1 h1:+rfw75/Zh8EopNlG652TGDXlLgJflj6XWxJ9yCVpJws=
 github.com/protolambda/ztyp v0.2.1/go.mod h1:9bYgKGqg3wJqT9ac1gI2hnVb0STQq7p/1lapqrqY1dU=
 github.com/prysmaticlabs/fastssz v0.0.0-20220602201051-e406b8091121 h1:geJA1V5NgjlkR4syD9wdf5L5RMVzAaFxAA6cgdV/JkQ=
@@ -1625,7 +1625,6 @@ golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210303074136-134d130e1a04/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210305034016-7844c3c200c3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210316164454-77fc1eacc6aa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1648,8 +1647,8 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220702020025-31831981b65f h1:xdsejrW/0Wf2diT5CPp3XmKUNbr7Xvw8kYilQ+6qjRY=
-golang.org/x/sys v0.0.0-20220702020025-31831981b65f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220818161305-2296e01440c6 h1:Sx/u41w+OwrInGdEckYmEuU5gHoGSL4QbDz3S9s6j4U=
+golang.org/x/sys v0.0.0-20220818161305-2296e01440c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=


### PR DESCRIPTION
@Inphi wrote
> Optimize the [polynomial evaluation function](https://github.com/Inphi/prysm/blob/9f96c2f9ace5f65730c160300d8c453c6d976f02/beacon-chain/core/blob/sidecar.go#L203). A hotspot in the evaluation function is the modular inverse operation. We made a [change](https://github.com/mdehoog/go-ethereum/pull/14) to geth that batches these operations to great effect. Doing the same in prysm will be effective as it uses the same implementation as geth’s.

Rather than modifying Prysm's implementation of `evaluate_polynomial_in_evaluation_form` in-place, I replaced it with Geth's implementation.