### PR TITLE
EIP-4844 Blobs sidecar API endpoint

### DIFF
--- a/beacon-chain/node/BUILD.bazel
+++ b/beacon-chain/node/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
         "//runtime/debug:go_default_library",
         "//runtime/prereqs:go_default_library",
         "//runtime/version:go_default_library",
+        "//async:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_ferranbt_fastssz//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",

--- a/beacon-chain/rpc/apimiddleware/custom_handlers.go
+++ b/beacon-chain/rpc/apimiddleware/custom_handlers.go
@@ -40,6 +40,14 @@ func handleGetBeaconStateSSZ(m *apimiddleware.ApiProxyMiddleware, endpoint apimi
 	return handleGetSSZ(m, endpoint, w, req, config)
 }
 
+func handleGetBlobsSidecarSSZ(m *apimiddleware.ApiProxyMiddleware, endpoint apimiddleware.Endpoint, w http.ResponseWriter, req *http.Request) (handled bool) {
+	config := sszConfig{
+		fileName:     "blobs_sidecar.ssz",
+		responseJson: &sszResponseJson{},
+	}
+	return handleGetSSZ(m, endpoint, w, req, config)
+}
+
 func handleGetBeaconBlockSSZ(m *apimiddleware.ApiProxyMiddleware, endpoint apimiddleware.Endpoint, w http.ResponseWriter, req *http.Request) (handled bool) {
 	config := sszConfig{
 		fileName:     "beacon_block.ssz",

--- a/beacon-chain/rpc/apimiddleware/custom_hooks.go
+++ b/beacon-chain/rpc/apimiddleware/custom_hooks.go
@@ -406,6 +406,44 @@ type tempSyncSubcommitteeValidatorsJson struct {
 	Validators []string `json:"validators"`
 }
 
+type tempBlobJson struct {
+	Data string `json:"data"`
+}
+
+type tempBlobsSidecarJson struct {
+	BeaconBlockRoot string         `json:"beacon_block_root"`
+	BeaconBlockSlot string         `json:"beacon_block_slot"`
+	Blobs           []tempBlobJson `json:"blobs"`
+	AggregatedProof string         `json:"kzg_aggregated_proof"`
+}
+
+type tempBlobsResponseJson struct {
+	Data tempBlobsSidecarJson `json:"data"`
+}
+
+// This takes the blobs list and exposes the data field of each blob as the blob content itself in the json
+func prepareBlobsResponse(body []byte, responseContainer interface{}) (apimiddleware.RunDefault, apimiddleware.ErrorJson) {
+	tempContainer := &tempBlobsResponseJson{}
+	if err := json.Unmarshal(body, tempContainer); err != nil {
+		return false, apimiddleware.InternalServerErrorWithMessage(err, "could not unmarshal response into temp container")
+	}
+	container, ok := responseContainer.(*blobsSidecarResponseJson)
+	if !ok {
+		return false, apimiddleware.InternalServerError(errors.New("container is not of the correct type"))
+	}
+
+	container.Data = &blobsSidecarJson{
+		BeaconBlockRoot: tempContainer.Data.BeaconBlockRoot,
+		BeaconBlockSlot: tempContainer.Data.BeaconBlockSlot,
+		Blobs:           make([]string, len(tempContainer.Data.Blobs)),
+		AggregatedProof: tempContainer.Data.AggregatedProof,
+	}
+	for i, blob := range tempContainer.Data.Blobs {
+		container.Data.Blobs[i] = blob.Data
+	}
+	return false, nil
+}
+
 // https://ethereum.github.io/beacon-APIs/?urls.primaryName=v2.0.0#/Beacon/getEpochSyncCommittees returns validator_aggregates as a nested array.
 // grpc-gateway returns a struct with nested fields which we have to transform into a plain 2D array.
 func prepareValidatorAggregates(body []byte, responseContainer interface{}) (apimiddleware.RunDefault, apimiddleware.ErrorJson) {

--- a/beacon-chain/rpc/apimiddleware/endpoint_factory.go
+++ b/beacon-chain/rpc/apimiddleware/endpoint_factory.go
@@ -68,6 +68,7 @@ func (_ *BeaconEndpointFactory) Paths() []string {
 		"/eth/v1/validator/sync_committee_contribution",
 		"/eth/v1/validator/contribution_and_proofs",
 		"/eth/v1/validator/prepare_beacon_proposer",
+		"/eth/v1/blobs/sidecar/{block_id}",
 	}
 }
 
@@ -120,6 +121,12 @@ func (_ *BeaconEndpointFactory) Create(path string) (*apimiddleware.Endpoint, er
 	case "/eth/v1/beacon/blocks/{block_id}":
 		endpoint.GetResponse = &blockResponseJson{}
 		endpoint.CustomHandlers = []apimiddleware.CustomHandler{handleGetBeaconBlockSSZ}
+	case "/eth/v1/blobs/sidecar/{block_id}":
+		endpoint.GetResponse = &blobsSidecarResponseJson{}
+		endpoint.CustomHandlers = []apimiddleware.CustomHandler{handleGetBlobsSidecarSSZ}
+		endpoint.Hooks = apimiddleware.HookCollection{
+			OnPreDeserializeGrpcResponseBodyIntoContainer: prepareBlobsResponse,
+		}
 	case "/eth/v2/beacon/blocks/{block_id}":
 		endpoint.GetResponse = &blockV2ResponseJson{}
 		endpoint.Hooks = apimiddleware.HookCollection{

--- a/beacon-chain/rpc/apimiddleware/structs.go
+++ b/beacon-chain/rpc/apimiddleware/structs.go
@@ -965,3 +965,15 @@ type eventErrorJson struct {
 	StatusCode int    `json:"status_code"`
 	Message    string `json:"message"`
 }
+
+// 4844
+type blobsSidecarJson struct {
+	BeaconBlockRoot string   `json:"beacon_block_root" hex:"true"`
+	BeaconBlockSlot string   `json:"beacon_block_slot"`
+	Blobs           []string `json:"blobs" hex:"true"`
+	AggregatedProof string   `json:"kzg_aggregated_proof" hex:"true"`
+}
+
+type blobsSidecarResponseJson struct {
+	Data *blobsSidecarJson `json:"data"`
+}

--- a/beacon-chain/rpc/eth/beacon/BUILD.bazel
+++ b/beacon-chain/rpc/eth/beacon/BUILD.bazel
@@ -3,6 +3,7 @@ load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "blobs.go",
         "blocks.go",
         "config.go",
         "log.go",

--- a/beacon-chain/rpc/eth/beacon/blobs.go
+++ b/beacon-chain/rpc/eth/beacon/blobs.go
@@ -1,0 +1,39 @@
+package beacon
+
+import (
+	"context"
+	"fmt"
+	"github.com/pkg/errors"
+	ethpbv1 "github.com/prysmaticlabs/prysm/proto/eth/v1"
+)
+
+func (bs *Server) GetBlobsSidecar(ctx context.Context, req *ethpbv1.BlobsRequest) (*ethpbv1.BlobsResponse, error) {
+	blk, err := bs.blockFromBlockID(ctx, req.BlockId)
+	err = handleGetBlockError(blk, err)
+	if err != nil {
+		return nil, errors.Wrap(err, "GetBlobs")
+	}
+	root, err := blk.Block().HashTreeRoot()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to htr block")
+	}
+	sidecar, err := bs.BeaconDB.BlobsSidecar(ctx, root)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get blobs sidecar for block %x", root)
+	}
+	var blobs []*ethpbv1.Blob
+	for _, b := range sidecar.Blobs {
+		var data []byte
+		// go through each element, concat them
+		for _, el := range b.Blob {
+			data = append(data, el...)
+		}
+		blobs = append(blobs, &ethpbv1.Blob{Data: data})
+	}
+	return &ethpbv1.BlobsResponse{
+		BeaconBlockRoot: sidecar.BeaconBlockRoot,
+		BeaconBlockSlot: uint64(sidecar.BeaconBlockSlot),
+		Blobs:           blobs,
+		AggregatedProof: sidecar.AggregatedProof,
+	}, nil
+}

--- a/beacon-chain/sync/initial-sync/BUILD.bazel
+++ b/beacon-chain/sync/initial-sync/BUILD.bazel
@@ -24,6 +24,8 @@ go_library(
         "//beacon-chain/core/transition:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/p2p:go_default_library",
+        "//beacon-chain/core/blob:go_default_library",
+        "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/p2p/peers/scorers:go_default_library",
         "//beacon-chain/p2p/types:go_default_library",
         "//beacon-chain/sync:go_default_library",

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213
 	github.com/kevinms/leakybucket-go v0.0.0-20200115003610-082473db97ca
-	github.com/kilic/bls12-381 v0.1.1-0.20210208205449-6045b0235e36
 	github.com/kr/pretty v0.3.0
 	github.com/libp2p/go-libp2p v0.18.0
 	github.com/libp2p/go-libp2p-blankhost v0.3.0
@@ -152,6 +151,7 @@ require (
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a // indirect
 	github.com/karalabe/usb v0.0.2 // indirect
+	github.com/kilic/bls12-381 v0.1.1-0.20210208205449-6045b0235e36 // indirect
 	github.com/klauspost/compress v1.15.1 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.12 // indirect
 	github.com/koron/go-ssdp v0.0.2 // indirect

--- a/nogo_config.json
+++ b/nogo_config.json
@@ -77,7 +77,8 @@
       ".*/.*mock\\.go": "Mocks are OK",
       ".*testmain\\.go$": "Fuzz",
       "proto/.*": "Generated protobuf related code",
-      "tools/analyzers/properpermissions/testdata/.*": "Analyzer breaks rules"
+      "tools/analyzers/properpermissions/testdata/.*": "Analyzer breaks rules",
+      "beacon-chain/sync/.*": "experimentation"
     }
   },
   "featureconfig": {

--- a/nogo_config.json
+++ b/nogo_config.json
@@ -175,7 +175,8 @@
       ".*\\.pb.*.go": "Generated code is ok",
       ".*generated\\.ssz\\.go": "Generated code is ok",
       ".*_test\\.go": "Tests are ok (for now)",
-      "tools/analyzers/ineffassign/ineffassign\\.go": "3rd party code with a massive switch statement"
+      "tools/analyzers/ineffassign/ineffassign\\.go": "3rd party code with a massive switch statement",
+      "beacon-chain/sync/.*": "experimentation"
     }
   }
 }

--- a/proto/eth/ext/options.pb.go
+++ b/proto/eth/ext/options.pb.go
@@ -7,9 +7,9 @@
 package ext
 
 import (
+	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	descriptorpb "google.golang.org/protobuf/types/descriptorpb"
 	reflect "reflect"
 )
 
@@ -22,7 +22,7 @@ const (
 
 var file_proto_eth_ext_options_proto_extTypes = []protoimpl.ExtensionInfo{
 	{
-		ExtendedType:  (*descriptorpb.FieldOptions)(nil),
+		ExtendedType:  (*descriptor.FieldOptions)(nil),
 		ExtensionType: (*string)(nil),
 		Field:         50000,
 		Name:          "ethereum.eth.ext.cast_type",
@@ -30,7 +30,7 @@ var file_proto_eth_ext_options_proto_extTypes = []protoimpl.ExtensionInfo{
 		Filename:      "proto/eth/ext/options.proto",
 	},
 	{
-		ExtendedType:  (*descriptorpb.FieldOptions)(nil),
+		ExtendedType:  (*descriptor.FieldOptions)(nil),
 		ExtensionType: (*string)(nil),
 		Field:         50001,
 		Name:          "ethereum.eth.ext.ssz_size",
@@ -38,7 +38,7 @@ var file_proto_eth_ext_options_proto_extTypes = []protoimpl.ExtensionInfo{
 		Filename:      "proto/eth/ext/options.proto",
 	},
 	{
-		ExtendedType:  (*descriptorpb.FieldOptions)(nil),
+		ExtendedType:  (*descriptor.FieldOptions)(nil),
 		ExtensionType: (*string)(nil),
 		Field:         50002,
 		Name:          "ethereum.eth.ext.ssz_max",
@@ -46,7 +46,7 @@ var file_proto_eth_ext_options_proto_extTypes = []protoimpl.ExtensionInfo{
 		Filename:      "proto/eth/ext/options.proto",
 	},
 	{
-		ExtendedType:  (*descriptorpb.FieldOptions)(nil),
+		ExtendedType:  (*descriptor.FieldOptions)(nil),
 		ExtensionType: (*string)(nil),
 		Field:         50003,
 		Name:          "ethereum.eth.ext.spec_name",
@@ -55,7 +55,7 @@ var file_proto_eth_ext_options_proto_extTypes = []protoimpl.ExtensionInfo{
 	},
 }
 
-// Extension fields to descriptorpb.FieldOptions.
+// Extension fields to descriptor.FieldOptions.
 var (
 	// optional string cast_type = 50000;
 	E_CastType = &file_proto_eth_ext_options_proto_extTypes[0]
@@ -102,7 +102,7 @@ var file_proto_eth_ext_options_proto_rawDesc = []byte{
 }
 
 var file_proto_eth_ext_options_proto_goTypes = []interface{}{
-	(*descriptorpb.FieldOptions)(nil), // 0: google.protobuf.FieldOptions
+	(*descriptor.FieldOptions)(nil), // 0: google.protobuf.FieldOptions
 }
 var file_proto_eth_ext_options_proto_depIdxs = []int32{
 	0, // 0: ethereum.eth.ext.cast_type:extendee -> google.protobuf.FieldOptions

--- a/proto/eth/service/beacon_chain_service.pb.go
+++ b/proto/eth/service/beacon_chain_service.pb.go
@@ -51,7 +51,7 @@ var file_proto_eth_service_beacon_chain_service_proto_rawDesc = []byte{
 	0x76, 0x32, 0x2f, 0x73, 0x73, 0x7a, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x21, 0x70, 0x72,
 	0x6f, 0x74, 0x6f, 0x2f, 0x65, 0x74, 0x68, 0x2f, 0x76, 0x32, 0x2f, 0x73, 0x79, 0x6e, 0x63, 0x5f,
 	0x63, 0x6f, 0x6d, 0x6d, 0x69, 0x74, 0x74, 0x65, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x32,
-	0x86, 0x27, 0x0a, 0x0b, 0x42, 0x65, 0x61, 0x63, 0x6f, 0x6e, 0x43, 0x68, 0x61, 0x69, 0x6e, 0x12,
+	0x80, 0x28, 0x0a, 0x0b, 0x42, 0x65, 0x61, 0x63, 0x6f, 0x6e, 0x43, 0x68, 0x61, 0x69, 0x6e, 0x12,
 	0x6f, 0x0a, 0x0a, 0x47, 0x65, 0x74, 0x47, 0x65, 0x6e, 0x65, 0x73, 0x69, 0x73, 0x12, 0x16, 0x2e,
 	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
 	0x45, 0x6d, 0x70, 0x74, 0x79, 0x1a, 0x20, 0x2e, 0x65, 0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d,
@@ -363,17 +363,25 @@ var file_proto_eth_service_beacon_chain_service_proto_rawDesc = []byte{
 	0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x30, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x2a, 0x12, 0x28,
 	0x2f, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c, 0x2f, 0x65, 0x74, 0x68, 0x2f, 0x76, 0x31,
 	0x2f, 0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x2f, 0x64, 0x65, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x5f,
-	0x63, 0x6f, 0x6e, 0x74, 0x72, 0x61, 0x63, 0x74, 0x42, 0x95, 0x01, 0x0a, 0x18, 0x6f, 0x72, 0x67,
-	0x2e, 0x65, 0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d, 0x2e, 0x65, 0x74, 0x68, 0x2e, 0x73, 0x65,
-	0x72, 0x76, 0x69, 0x63, 0x65, 0x42, 0x17, 0x42, 0x65, 0x61, 0x63, 0x6f, 0x6e, 0x43, 0x68, 0x61,
-	0x69, 0x6e, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01,
-	0x5a, 0x30, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x70, 0x72, 0x79,
-	0x73, 0x6d, 0x61, 0x74, 0x69, 0x63, 0x6c, 0x61, 0x62, 0x73, 0x2f, 0x70, 0x72, 0x79, 0x73, 0x6d,
-	0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x65, 0x74, 0x68, 0x2f, 0x73, 0x65, 0x72, 0x76, 0x69,
-	0x63, 0x65, 0xaa, 0x02, 0x14, 0x45, 0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d, 0x2e, 0x45, 0x74,
-	0x68, 0x2e, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0xca, 0x02, 0x14, 0x45, 0x74, 0x68, 0x65,
-	0x72, 0x65, 0x75, 0x6d, 0x5c, 0x45, 0x74, 0x68, 0x5c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65,
-	0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x63, 0x6f, 0x6e, 0x74, 0x72, 0x61, 0x63, 0x74, 0x12, 0x78, 0x0a, 0x0f, 0x47, 0x65, 0x74, 0x42,
+	0x6c, 0x6f, 0x62, 0x73, 0x53, 0x69, 0x64, 0x65, 0x63, 0x61, 0x72, 0x12, 0x1d, 0x2e, 0x65, 0x74,
+	0x68, 0x65, 0x72, 0x65, 0x75, 0x6d, 0x2e, 0x65, 0x74, 0x68, 0x2e, 0x76, 0x31, 0x2e, 0x42, 0x6c,
+	0x6f, 0x62, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x1e, 0x2e, 0x65, 0x74, 0x68,
+	0x65, 0x72, 0x65, 0x75, 0x6d, 0x2e, 0x65, 0x74, 0x68, 0x2e, 0x76, 0x31, 0x2e, 0x42, 0x6c, 0x6f,
+	0x62, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x26, 0x82, 0xd3, 0xe4, 0x93,
+	0x02, 0x20, 0x12, 0x1e, 0x2f, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c, 0x2f, 0x65, 0x74,
+	0x68, 0x2f, 0x76, 0x31, 0x2f, 0x62, 0x6c, 0x6f, 0x62, 0x73, 0x2f, 0x73, 0x69, 0x64, 0x65, 0x63,
+	0x61, 0x72, 0x42, 0x95, 0x01, 0x0a, 0x18, 0x6f, 0x72, 0x67, 0x2e, 0x65, 0x74, 0x68, 0x65, 0x72,
+	0x65, 0x75, 0x6d, 0x2e, 0x65, 0x74, 0x68, 0x2e, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x42,
+	0x17, 0x42, 0x65, 0x61, 0x63, 0x6f, 0x6e, 0x43, 0x68, 0x61, 0x69, 0x6e, 0x53, 0x65, 0x72, 0x76,
+	0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a, 0x30, 0x67, 0x69, 0x74, 0x68,
+	0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x70, 0x72, 0x79, 0x73, 0x6d, 0x61, 0x74, 0x69, 0x63,
+	0x6c, 0x61, 0x62, 0x73, 0x2f, 0x70, 0x72, 0x79, 0x73, 0x6d, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+	0x2f, 0x65, 0x74, 0x68, 0x2f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0xaa, 0x02, 0x14, 0x45,
+	0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d, 0x2e, 0x45, 0x74, 0x68, 0x2e, 0x53, 0x65, 0x72, 0x76,
+	0x69, 0x63, 0x65, 0xca, 0x02, 0x14, 0x45, 0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d, 0x5c, 0x45,
+	0x74, 0x68, 0x5c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74,
+	0x6f, 0x33,
 }
 
 var file_proto_eth_service_beacon_chain_service_proto_goTypes = []interface{}{
@@ -396,30 +404,32 @@ var file_proto_eth_service_beacon_chain_service_proto_goTypes = []interface{}{
 	(*v1.ProposerSlashing)(nil),                  // 16: ethereum.eth.v1.ProposerSlashing
 	(*v1.SignedVoluntaryExit)(nil),               // 17: ethereum.eth.v1.SignedVoluntaryExit
 	(*v2.SubmitPoolSyncCommitteeSignatures)(nil), // 18: ethereum.eth.v2.SubmitPoolSyncCommitteeSignatures
-	(*v1.GenesisResponse)(nil),                   // 19: ethereum.eth.v1.GenesisResponse
-	(*v1.WeakSubjectivityResponse)(nil),          // 20: ethereum.eth.v1.WeakSubjectivityResponse
-	(*v1.StateRootResponse)(nil),                 // 21: ethereum.eth.v1.StateRootResponse
-	(*v1.StateForkResponse)(nil),                 // 22: ethereum.eth.v1.StateForkResponse
-	(*v1.StateFinalityCheckpointResponse)(nil),   // 23: ethereum.eth.v1.StateFinalityCheckpointResponse
-	(*v1.StateValidatorsResponse)(nil),           // 24: ethereum.eth.v1.StateValidatorsResponse
-	(*v1.StateValidatorResponse)(nil),            // 25: ethereum.eth.v1.StateValidatorResponse
-	(*v1.ValidatorBalancesResponse)(nil),         // 26: ethereum.eth.v1.ValidatorBalancesResponse
-	(*v1.StateCommitteesResponse)(nil),           // 27: ethereum.eth.v1.StateCommitteesResponse
-	(*v2.StateSyncCommitteesResponse)(nil),       // 28: ethereum.eth.v2.StateSyncCommitteesResponse
-	(*v1.BlockHeadersResponse)(nil),              // 29: ethereum.eth.v1.BlockHeadersResponse
-	(*v1.BlockHeaderResponse)(nil),               // 30: ethereum.eth.v1.BlockHeaderResponse
-	(*v1.BlockRootResponse)(nil),                 // 31: ethereum.eth.v1.BlockRootResponse
-	(*v1.BlockResponse)(nil),                     // 32: ethereum.eth.v1.BlockResponse
-	(*v1.BlockSSZResponse)(nil),                  // 33: ethereum.eth.v1.BlockSSZResponse
-	(*v2.BlockResponseV2)(nil),                   // 34: ethereum.eth.v2.BlockResponseV2
-	(*v1.BlockAttestationsResponse)(nil),         // 35: ethereum.eth.v1.BlockAttestationsResponse
-	(*v1.AttestationsPoolResponse)(nil),          // 36: ethereum.eth.v1.AttestationsPoolResponse
-	(*v1.AttesterSlashingsPoolResponse)(nil),     // 37: ethereum.eth.v1.AttesterSlashingsPoolResponse
-	(*v1.ProposerSlashingPoolResponse)(nil),      // 38: ethereum.eth.v1.ProposerSlashingPoolResponse
-	(*v1.VoluntaryExitsPoolResponse)(nil),        // 39: ethereum.eth.v1.VoluntaryExitsPoolResponse
-	(*v1.ForkScheduleResponse)(nil),              // 40: ethereum.eth.v1.ForkScheduleResponse
-	(*v1.SpecResponse)(nil),                      // 41: ethereum.eth.v1.SpecResponse
-	(*v1.DepositContractResponse)(nil),           // 42: ethereum.eth.v1.DepositContractResponse
+	(*v1.BlobsRequest)(nil),                      // 19: ethereum.eth.v1.BlobsRequest
+	(*v1.GenesisResponse)(nil),                   // 20: ethereum.eth.v1.GenesisResponse
+	(*v1.WeakSubjectivityResponse)(nil),          // 21: ethereum.eth.v1.WeakSubjectivityResponse
+	(*v1.StateRootResponse)(nil),                 // 22: ethereum.eth.v1.StateRootResponse
+	(*v1.StateForkResponse)(nil),                 // 23: ethereum.eth.v1.StateForkResponse
+	(*v1.StateFinalityCheckpointResponse)(nil),   // 24: ethereum.eth.v1.StateFinalityCheckpointResponse
+	(*v1.StateValidatorsResponse)(nil),           // 25: ethereum.eth.v1.StateValidatorsResponse
+	(*v1.StateValidatorResponse)(nil),            // 26: ethereum.eth.v1.StateValidatorResponse
+	(*v1.ValidatorBalancesResponse)(nil),         // 27: ethereum.eth.v1.ValidatorBalancesResponse
+	(*v1.StateCommitteesResponse)(nil),           // 28: ethereum.eth.v1.StateCommitteesResponse
+	(*v2.StateSyncCommitteesResponse)(nil),       // 29: ethereum.eth.v2.StateSyncCommitteesResponse
+	(*v1.BlockHeadersResponse)(nil),              // 30: ethereum.eth.v1.BlockHeadersResponse
+	(*v1.BlockHeaderResponse)(nil),               // 31: ethereum.eth.v1.BlockHeaderResponse
+	(*v1.BlockRootResponse)(nil),                 // 32: ethereum.eth.v1.BlockRootResponse
+	(*v1.BlockResponse)(nil),                     // 33: ethereum.eth.v1.BlockResponse
+	(*v1.BlockSSZResponse)(nil),                  // 34: ethereum.eth.v1.BlockSSZResponse
+	(*v2.BlockResponseV2)(nil),                   // 35: ethereum.eth.v2.BlockResponseV2
+	(*v1.BlockAttestationsResponse)(nil),         // 36: ethereum.eth.v1.BlockAttestationsResponse
+	(*v1.AttestationsPoolResponse)(nil),          // 37: ethereum.eth.v1.AttestationsPoolResponse
+	(*v1.AttesterSlashingsPoolResponse)(nil),     // 38: ethereum.eth.v1.AttesterSlashingsPoolResponse
+	(*v1.ProposerSlashingPoolResponse)(nil),      // 39: ethereum.eth.v1.ProposerSlashingPoolResponse
+	(*v1.VoluntaryExitsPoolResponse)(nil),        // 40: ethereum.eth.v1.VoluntaryExitsPoolResponse
+	(*v1.ForkScheduleResponse)(nil),              // 41: ethereum.eth.v1.ForkScheduleResponse
+	(*v1.SpecResponse)(nil),                      // 42: ethereum.eth.v1.SpecResponse
+	(*v1.DepositContractResponse)(nil),           // 43: ethereum.eth.v1.DepositContractResponse
+	(*v1.BlobsResponse)(nil),                     // 44: ethereum.eth.v1.BlobsResponse
 }
 var file_proto_eth_service_beacon_chain_service_proto_depIdxs = []int32{
 	0,  // 0: ethereum.eth.service.BeaconChain.GetGenesis:input_type -> google.protobuf.Empty
@@ -456,42 +466,44 @@ var file_proto_eth_service_beacon_chain_service_proto_depIdxs = []int32{
 	0,  // 31: ethereum.eth.service.BeaconChain.GetForkSchedule:input_type -> google.protobuf.Empty
 	0,  // 32: ethereum.eth.service.BeaconChain.GetSpec:input_type -> google.protobuf.Empty
 	0,  // 33: ethereum.eth.service.BeaconChain.GetDepositContract:input_type -> google.protobuf.Empty
-	19, // 34: ethereum.eth.service.BeaconChain.GetGenesis:output_type -> ethereum.eth.v1.GenesisResponse
-	20, // 35: ethereum.eth.service.BeaconChain.GetWeakSubjectivity:output_type -> ethereum.eth.v1.WeakSubjectivityResponse
-	21, // 36: ethereum.eth.service.BeaconChain.GetStateRoot:output_type -> ethereum.eth.v1.StateRootResponse
-	22, // 37: ethereum.eth.service.BeaconChain.GetStateFork:output_type -> ethereum.eth.v1.StateForkResponse
-	23, // 38: ethereum.eth.service.BeaconChain.GetFinalityCheckpoints:output_type -> ethereum.eth.v1.StateFinalityCheckpointResponse
-	24, // 39: ethereum.eth.service.BeaconChain.ListValidators:output_type -> ethereum.eth.v1.StateValidatorsResponse
-	25, // 40: ethereum.eth.service.BeaconChain.GetValidator:output_type -> ethereum.eth.v1.StateValidatorResponse
-	26, // 41: ethereum.eth.service.BeaconChain.ListValidatorBalances:output_type -> ethereum.eth.v1.ValidatorBalancesResponse
-	27, // 42: ethereum.eth.service.BeaconChain.ListCommittees:output_type -> ethereum.eth.v1.StateCommitteesResponse
-	28, // 43: ethereum.eth.service.BeaconChain.ListSyncCommittees:output_type -> ethereum.eth.v2.StateSyncCommitteesResponse
-	29, // 44: ethereum.eth.service.BeaconChain.ListBlockHeaders:output_type -> ethereum.eth.v1.BlockHeadersResponse
-	30, // 45: ethereum.eth.service.BeaconChain.GetBlockHeader:output_type -> ethereum.eth.v1.BlockHeaderResponse
-	0,  // 46: ethereum.eth.service.BeaconChain.SubmitBlock:output_type -> google.protobuf.Empty
-	0,  // 47: ethereum.eth.service.BeaconChain.SubmitBlockSSZ:output_type -> google.protobuf.Empty
-	0,  // 48: ethereum.eth.service.BeaconChain.SubmitBlindedBlock:output_type -> google.protobuf.Empty
-	0,  // 49: ethereum.eth.service.BeaconChain.SubmitBlindedBlockSSZ:output_type -> google.protobuf.Empty
-	31, // 50: ethereum.eth.service.BeaconChain.GetBlockRoot:output_type -> ethereum.eth.v1.BlockRootResponse
-	32, // 51: ethereum.eth.service.BeaconChain.GetBlock:output_type -> ethereum.eth.v1.BlockResponse
-	33, // 52: ethereum.eth.service.BeaconChain.GetBlockSSZ:output_type -> ethereum.eth.v1.BlockSSZResponse
-	34, // 53: ethereum.eth.service.BeaconChain.GetBlockV2:output_type -> ethereum.eth.v2.BlockResponseV2
-	10, // 54: ethereum.eth.service.BeaconChain.GetBlockSSZV2:output_type -> ethereum.eth.v2.SSZContainer
-	35, // 55: ethereum.eth.service.BeaconChain.ListBlockAttestations:output_type -> ethereum.eth.v1.BlockAttestationsResponse
-	36, // 56: ethereum.eth.service.BeaconChain.ListPoolAttestations:output_type -> ethereum.eth.v1.AttestationsPoolResponse
-	0,  // 57: ethereum.eth.service.BeaconChain.SubmitAttestations:output_type -> google.protobuf.Empty
-	37, // 58: ethereum.eth.service.BeaconChain.ListPoolAttesterSlashings:output_type -> ethereum.eth.v1.AttesterSlashingsPoolResponse
-	0,  // 59: ethereum.eth.service.BeaconChain.SubmitAttesterSlashing:output_type -> google.protobuf.Empty
-	38, // 60: ethereum.eth.service.BeaconChain.ListPoolProposerSlashings:output_type -> ethereum.eth.v1.ProposerSlashingPoolResponse
-	0,  // 61: ethereum.eth.service.BeaconChain.SubmitProposerSlashing:output_type -> google.protobuf.Empty
-	39, // 62: ethereum.eth.service.BeaconChain.ListPoolVoluntaryExits:output_type -> ethereum.eth.v1.VoluntaryExitsPoolResponse
-	0,  // 63: ethereum.eth.service.BeaconChain.SubmitVoluntaryExit:output_type -> google.protobuf.Empty
-	0,  // 64: ethereum.eth.service.BeaconChain.SubmitPoolSyncCommitteeSignatures:output_type -> google.protobuf.Empty
-	40, // 65: ethereum.eth.service.BeaconChain.GetForkSchedule:output_type -> ethereum.eth.v1.ForkScheduleResponse
-	41, // 66: ethereum.eth.service.BeaconChain.GetSpec:output_type -> ethereum.eth.v1.SpecResponse
-	42, // 67: ethereum.eth.service.BeaconChain.GetDepositContract:output_type -> ethereum.eth.v1.DepositContractResponse
-	34, // [34:68] is the sub-list for method output_type
-	0,  // [0:34] is the sub-list for method input_type
+	19, // 34: ethereum.eth.service.BeaconChain.GetBlobsSidecar:input_type -> ethereum.eth.v1.BlobsRequest
+	20, // 35: ethereum.eth.service.BeaconChain.GetGenesis:output_type -> ethereum.eth.v1.GenesisResponse
+	21, // 36: ethereum.eth.service.BeaconChain.GetWeakSubjectivity:output_type -> ethereum.eth.v1.WeakSubjectivityResponse
+	22, // 37: ethereum.eth.service.BeaconChain.GetStateRoot:output_type -> ethereum.eth.v1.StateRootResponse
+	23, // 38: ethereum.eth.service.BeaconChain.GetStateFork:output_type -> ethereum.eth.v1.StateForkResponse
+	24, // 39: ethereum.eth.service.BeaconChain.GetFinalityCheckpoints:output_type -> ethereum.eth.v1.StateFinalityCheckpointResponse
+	25, // 40: ethereum.eth.service.BeaconChain.ListValidators:output_type -> ethereum.eth.v1.StateValidatorsResponse
+	26, // 41: ethereum.eth.service.BeaconChain.GetValidator:output_type -> ethereum.eth.v1.StateValidatorResponse
+	27, // 42: ethereum.eth.service.BeaconChain.ListValidatorBalances:output_type -> ethereum.eth.v1.ValidatorBalancesResponse
+	28, // 43: ethereum.eth.service.BeaconChain.ListCommittees:output_type -> ethereum.eth.v1.StateCommitteesResponse
+	29, // 44: ethereum.eth.service.BeaconChain.ListSyncCommittees:output_type -> ethereum.eth.v2.StateSyncCommitteesResponse
+	30, // 45: ethereum.eth.service.BeaconChain.ListBlockHeaders:output_type -> ethereum.eth.v1.BlockHeadersResponse
+	31, // 46: ethereum.eth.service.BeaconChain.GetBlockHeader:output_type -> ethereum.eth.v1.BlockHeaderResponse
+	0,  // 47: ethereum.eth.service.BeaconChain.SubmitBlock:output_type -> google.protobuf.Empty
+	0,  // 48: ethereum.eth.service.BeaconChain.SubmitBlockSSZ:output_type -> google.protobuf.Empty
+	0,  // 49: ethereum.eth.service.BeaconChain.SubmitBlindedBlock:output_type -> google.protobuf.Empty
+	0,  // 50: ethereum.eth.service.BeaconChain.SubmitBlindedBlockSSZ:output_type -> google.protobuf.Empty
+	32, // 51: ethereum.eth.service.BeaconChain.GetBlockRoot:output_type -> ethereum.eth.v1.BlockRootResponse
+	33, // 52: ethereum.eth.service.BeaconChain.GetBlock:output_type -> ethereum.eth.v1.BlockResponse
+	34, // 53: ethereum.eth.service.BeaconChain.GetBlockSSZ:output_type -> ethereum.eth.v1.BlockSSZResponse
+	35, // 54: ethereum.eth.service.BeaconChain.GetBlockV2:output_type -> ethereum.eth.v2.BlockResponseV2
+	10, // 55: ethereum.eth.service.BeaconChain.GetBlockSSZV2:output_type -> ethereum.eth.v2.SSZContainer
+	36, // 56: ethereum.eth.service.BeaconChain.ListBlockAttestations:output_type -> ethereum.eth.v1.BlockAttestationsResponse
+	37, // 57: ethereum.eth.service.BeaconChain.ListPoolAttestations:output_type -> ethereum.eth.v1.AttestationsPoolResponse
+	0,  // 58: ethereum.eth.service.BeaconChain.SubmitAttestations:output_type -> google.protobuf.Empty
+	38, // 59: ethereum.eth.service.BeaconChain.ListPoolAttesterSlashings:output_type -> ethereum.eth.v1.AttesterSlashingsPoolResponse
+	0,  // 60: ethereum.eth.service.BeaconChain.SubmitAttesterSlashing:output_type -> google.protobuf.Empty
+	39, // 61: ethereum.eth.service.BeaconChain.ListPoolProposerSlashings:output_type -> ethereum.eth.v1.ProposerSlashingPoolResponse
+	0,  // 62: ethereum.eth.service.BeaconChain.SubmitProposerSlashing:output_type -> google.protobuf.Empty
+	40, // 63: ethereum.eth.service.BeaconChain.ListPoolVoluntaryExits:output_type -> ethereum.eth.v1.VoluntaryExitsPoolResponse
+	0,  // 64: ethereum.eth.service.BeaconChain.SubmitVoluntaryExit:output_type -> google.protobuf.Empty
+	0,  // 65: ethereum.eth.service.BeaconChain.SubmitPoolSyncCommitteeSignatures:output_type -> google.protobuf.Empty
+	41, // 66: ethereum.eth.service.BeaconChain.GetForkSchedule:output_type -> ethereum.eth.v1.ForkScheduleResponse
+	42, // 67: ethereum.eth.service.BeaconChain.GetSpec:output_type -> ethereum.eth.v1.SpecResponse
+	43, // 68: ethereum.eth.service.BeaconChain.GetDepositContract:output_type -> ethereum.eth.v1.DepositContractResponse
+	44, // 69: ethereum.eth.service.BeaconChain.GetBlobsSidecar:output_type -> ethereum.eth.v1.BlobsResponse
+	35, // [35:70] is the sub-list for method output_type
+	0,  // [0:35] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name
@@ -567,6 +579,7 @@ type BeaconChainClient interface {
 	GetForkSchedule(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*v1.ForkScheduleResponse, error)
 	GetSpec(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*v1.SpecResponse, error)
 	GetDepositContract(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*v1.DepositContractResponse, error)
+	GetBlobsSidecar(ctx context.Context, in *v1.BlobsRequest, opts ...grpc.CallOption) (*v1.BlobsResponse, error)
 }
 
 type beaconChainClient struct {
@@ -883,6 +896,15 @@ func (c *beaconChainClient) GetDepositContract(ctx context.Context, in *empty.Em
 	return out, nil
 }
 
+func (c *beaconChainClient) GetBlobsSidecar(ctx context.Context, in *v1.BlobsRequest, opts ...grpc.CallOption) (*v1.BlobsResponse, error) {
+	out := new(v1.BlobsResponse)
+	err := c.cc.Invoke(ctx, "/ethereum.eth.service.BeaconChain/GetBlobsSidecar", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // BeaconChainServer is the server API for BeaconChain service.
 type BeaconChainServer interface {
 	GetGenesis(context.Context, *empty.Empty) (*v1.GenesisResponse, error)
@@ -919,6 +941,7 @@ type BeaconChainServer interface {
 	GetForkSchedule(context.Context, *empty.Empty) (*v1.ForkScheduleResponse, error)
 	GetSpec(context.Context, *empty.Empty) (*v1.SpecResponse, error)
 	GetDepositContract(context.Context, *empty.Empty) (*v1.DepositContractResponse, error)
+	GetBlobsSidecar(context.Context, *v1.BlobsRequest) (*v1.BlobsResponse, error)
 }
 
 // UnimplementedBeaconChainServer can be embedded to have forward compatible implementations.
@@ -1026,6 +1049,9 @@ func (*UnimplementedBeaconChainServer) GetSpec(context.Context, *empty.Empty) (*
 }
 func (*UnimplementedBeaconChainServer) GetDepositContract(context.Context, *empty.Empty) (*v1.DepositContractResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetDepositContract not implemented")
+}
+func (*UnimplementedBeaconChainServer) GetBlobsSidecar(context.Context, *v1.BlobsRequest) (*v1.BlobsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetBlobsSidecar not implemented")
 }
 
 func RegisterBeaconChainServer(s *grpc.Server, srv BeaconChainServer) {
@@ -1644,6 +1670,24 @@ func _BeaconChain_GetDepositContract_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _BeaconChain_GetBlobsSidecar_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(v1.BlobsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BeaconChainServer).GetBlobsSidecar(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/ethereum.eth.service.BeaconChain/GetBlobsSidecar",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BeaconChainServer).GetBlobsSidecar(ctx, req.(*v1.BlobsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _BeaconChain_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "ethereum.eth.service.BeaconChain",
 	HandlerType: (*BeaconChainServer)(nil),
@@ -1783,6 +1827,10 @@ var _BeaconChain_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetDepositContract",
 			Handler:    _BeaconChain_GetDepositContract_Handler,
+		},
+		{
+			MethodName: "GetBlobsSidecar",
+			Handler:    _BeaconChain_GetBlobsSidecar_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/proto/eth/service/beacon_chain_service.pb.gw.go
+++ b/proto/eth/service/beacon_chain_service.pb.gw.go
@@ -1464,6 +1464,42 @@ func local_request_BeaconChain_GetDepositContract_0(ctx context.Context, marshal
 
 }
 
+var (
+	filter_BeaconChain_GetBlobsSidecar_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+)
+
+func request_BeaconChain_GetBlobsSidecar_0(ctx context.Context, marshaler runtime.Marshaler, client BeaconChainClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq v1.BlobsRequest
+	var metadata runtime.ServerMetadata
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_BeaconChain_GetBlobsSidecar_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.GetBlobsSidecar(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_BeaconChain_GetBlobsSidecar_0(ctx context.Context, marshaler runtime.Marshaler, server BeaconChainServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq v1.BlobsRequest
+	var metadata runtime.ServerMetadata
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_BeaconChain_GetBlobsSidecar_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.GetBlobsSidecar(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 // RegisterBeaconChainHandlerServer registers the http handlers for service BeaconChain to "mux".
 // UnaryRPC     :call BeaconChainServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -2252,6 +2288,29 @@ func RegisterBeaconChainHandlerServer(ctx context.Context, mux *runtime.ServeMux
 
 	})
 
+	mux.Handle("GET", pattern_BeaconChain_GetBlobsSidecar_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/ethereum.eth.service.BeaconChain/GetBlobsSidecar")
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_BeaconChain_GetBlobsSidecar_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_BeaconChain_GetBlobsSidecar_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -2973,6 +3032,26 @@ func RegisterBeaconChainHandlerClient(ctx context.Context, mux *runtime.ServeMux
 
 	})
 
+	mux.Handle("GET", pattern_BeaconChain_GetBlobsSidecar_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req, "/ethereum.eth.service.BeaconChain/GetBlobsSidecar")
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_BeaconChain_GetBlobsSidecar_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_BeaconChain_GetBlobsSidecar_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -3044,6 +3123,8 @@ var (
 	pattern_BeaconChain_GetSpec_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"internal", "eth", "v1", "config", "spec"}, ""))
 
 	pattern_BeaconChain_GetDepositContract_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"internal", "eth", "v1", "config", "deposit_contract"}, ""))
+
+	pattern_BeaconChain_GetBlobsSidecar_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"internal", "eth", "v1", "blobs", "sidecar"}, ""))
 )
 
 var (
@@ -3114,4 +3195,6 @@ var (
 	forward_BeaconChain_GetSpec_0 = runtime.ForwardResponseMessage
 
 	forward_BeaconChain_GetDepositContract_0 = runtime.ForwardResponseMessage
+
+	forward_BeaconChain_GetBlobsSidecar_0 = runtime.ForwardResponseMessage
 )

--- a/proto/eth/service/beacon_chain_service.proto
+++ b/proto/eth/service/beacon_chain_service.proto
@@ -388,5 +388,10 @@ service BeaconChain {
   rpc GetDepositContract(google.protobuf.Empty) returns (v1.DepositContractResponse) {
     option (google.api.http) = {get: "/internal/eth/v1/config/deposit_contract"};
   }
+
+  // GetBlobs retrieves blob data by block ID and data hash
+  rpc GetBlobsSidecar(v1.BlobsRequest) returns (v1.BlobsResponse) {
+    option (google.api.http) = {get: "/internal/eth/v1/blobs/sidecar"};
+  }
 }
 

--- a/proto/eth/v1/attestation.pb.gw.go
+++ b/proto/eth/v1/attestation.pb.gw.go
@@ -1,3 +1,4 @@
 //go:build ignore
+// +build ignore
 
 package ignore

--- a/proto/eth/v1/beacon_block.pb.gw.go
+++ b/proto/eth/v1/beacon_block.pb.gw.go
@@ -1,3 +1,4 @@
 //go:build ignore
+// +build ignore
 
 package ignore

--- a/proto/eth/v1/beacon_chain.pb.go
+++ b/proto/eth/v1/beacon_chain.pb.go
@@ -2026,6 +2026,171 @@ func (x *WeakSubjectivityData) GetStateRoot() []byte {
 	return nil
 }
 
+type BlobsRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	BlockId []byte `protobuf:"bytes,1,opt,name=block_id,json=blockId,proto3" json:"block_id,omitempty"`
+}
+
+func (x *BlobsRequest) Reset() {
+	*x = BlobsRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[38]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *BlobsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BlobsRequest) ProtoMessage() {}
+
+func (x *BlobsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[38]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BlobsRequest.ProtoReflect.Descriptor instead.
+func (*BlobsRequest) Descriptor() ([]byte, []int) {
+	return file_proto_eth_v1_beacon_chain_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *BlobsRequest) GetBlockId() []byte {
+	if x != nil {
+		return x.BlockId
+	}
+	return nil
+}
+
+type Blob struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Data []byte `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
+}
+
+func (x *Blob) Reset() {
+	*x = Blob{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[39]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *Blob) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Blob) ProtoMessage() {}
+
+func (x *Blob) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[39]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Blob.ProtoReflect.Descriptor instead.
+func (*Blob) Descriptor() ([]byte, []int) {
+	return file_proto_eth_v1_beacon_chain_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *Blob) GetData() []byte {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
+type BlobsResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	BeaconBlockRoot []byte  `protobuf:"bytes,1,opt,name=beacon_block_root,json=beaconBlockRoot,proto3" json:"beacon_block_root,omitempty"`
+	BeaconBlockSlot uint64  `protobuf:"varint,2,opt,name=beacon_block_slot,json=beaconBlockSlot,proto3" json:"beacon_block_slot,omitempty"`
+	Blobs           []*Blob `protobuf:"bytes,3,rep,name=blobs,proto3" json:"blobs,omitempty"`
+	AggregatedProof []byte  `protobuf:"bytes,4,opt,name=aggregated_proof,json=aggregatedProof,proto3" json:"aggregated_proof,omitempty"`
+}
+
+func (x *BlobsResponse) Reset() {
+	*x = BlobsResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[40]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *BlobsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BlobsResponse) ProtoMessage() {}
+
+func (x *BlobsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[40]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BlobsResponse.ProtoReflect.Descriptor instead.
+func (*BlobsResponse) Descriptor() ([]byte, []int) {
+	return file_proto_eth_v1_beacon_chain_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *BlobsResponse) GetBeaconBlockRoot() []byte {
+	if x != nil {
+		return x.BeaconBlockRoot
+	}
+	return nil
+}
+
+func (x *BlobsResponse) GetBeaconBlockSlot() uint64 {
+	if x != nil {
+		return x.BeaconBlockSlot
+	}
+	return 0
+}
+
+func (x *BlobsResponse) GetBlobs() []*Blob {
+	if x != nil {
+		return x.Blobs
+	}
+	return nil
+}
+
+func (x *BlobsResponse) GetAggregatedProof() []byte {
+	if x != nil {
+		return x.AggregatedProof
+	}
+	return nil
+}
+
 type GenesisResponse_Genesis struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2039,7 +2204,7 @@ type GenesisResponse_Genesis struct {
 func (x *GenesisResponse_Genesis) Reset() {
 	*x = GenesisResponse_Genesis{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[38]
+		mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[41]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2052,7 +2217,7 @@ func (x *GenesisResponse_Genesis) String() string {
 func (*GenesisResponse_Genesis) ProtoMessage() {}
 
 func (x *GenesisResponse_Genesis) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[38]
+	mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[41]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2100,7 +2265,7 @@ type StateRootResponse_StateRoot struct {
 func (x *StateRootResponse_StateRoot) Reset() {
 	*x = StateRootResponse_StateRoot{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[39]
+		mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[42]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2113,7 +2278,7 @@ func (x *StateRootResponse_StateRoot) String() string {
 func (*StateRootResponse_StateRoot) ProtoMessage() {}
 
 func (x *StateRootResponse_StateRoot) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[39]
+	mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[42]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2149,7 +2314,7 @@ type StateFinalityCheckpointResponse_StateFinalityCheckpoint struct {
 func (x *StateFinalityCheckpointResponse_StateFinalityCheckpoint) Reset() {
 	*x = StateFinalityCheckpointResponse_StateFinalityCheckpoint{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[40]
+		mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[43]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2162,7 +2327,7 @@ func (x *StateFinalityCheckpointResponse_StateFinalityCheckpoint) String() strin
 func (*StateFinalityCheckpointResponse_StateFinalityCheckpoint) ProtoMessage() {}
 
 func (x *StateFinalityCheckpointResponse_StateFinalityCheckpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[40]
+	mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[43]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2529,15 +2694,31 @@ var file_proto_eth_v1_beacon_chain_proto_rawDesc = []byte{
 	0x70, 0x6f, 0x69, 0x6e, 0x74, 0x52, 0x0c, 0x77, 0x73, 0x43, 0x68, 0x65, 0x63, 0x6b, 0x70, 0x6f,
 	0x69, 0x6e, 0x74, 0x12, 0x1d, 0x0a, 0x0a, 0x73, 0x74, 0x61, 0x74, 0x65, 0x5f, 0x72, 0x6f, 0x6f,
 	0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x09, 0x73, 0x74, 0x61, 0x74, 0x65, 0x52, 0x6f,
-	0x6f, 0x74, 0x42, 0x7a, 0x0a, 0x13, 0x6f, 0x72, 0x67, 0x2e, 0x65, 0x74, 0x68, 0x65, 0x72, 0x65,
-	0x75, 0x6d, 0x2e, 0x65, 0x74, 0x68, 0x2e, 0x76, 0x31, 0x42, 0x10, 0x42, 0x65, 0x61, 0x63, 0x6f,
-	0x6e, 0x43, 0x68, 0x61, 0x69, 0x6e, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a, 0x2b, 0x67,
-	0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x70, 0x72, 0x79, 0x73, 0x6d, 0x61,
-	0x74, 0x69, 0x63, 0x6c, 0x61, 0x62, 0x73, 0x2f, 0x70, 0x72, 0x79, 0x73, 0x6d, 0x2f, 0x70, 0x72,
-	0x6f, 0x74, 0x6f, 0x2f, 0x65, 0x74, 0x68, 0x2f, 0x76, 0x31, 0xaa, 0x02, 0x0f, 0x45, 0x74, 0x68,
-	0x65, 0x72, 0x65, 0x75, 0x6d, 0x2e, 0x45, 0x74, 0x68, 0x2e, 0x56, 0x31, 0xca, 0x02, 0x0f, 0x45,
-	0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d, 0x5c, 0x45, 0x74, 0x68, 0x5c, 0x76, 0x31, 0x62, 0x06,
-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x6f, 0x74, 0x22, 0x29, 0x0a, 0x0c, 0x42, 0x6c, 0x6f, 0x62, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65,
+	0x73, 0x74, 0x12, 0x19, 0x0a, 0x08, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x5f, 0x69, 0x64, 0x18, 0x01,
+	0x20, 0x01, 0x28, 0x0c, 0x52, 0x07, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x49, 0x64, 0x22, 0x1a, 0x0a,
+	0x04, 0x42, 0x6c, 0x6f, 0x62, 0x12, 0x12, 0x0a, 0x04, 0x64, 0x61, 0x74, 0x61, 0x18, 0x01, 0x20,
+	0x01, 0x28, 0x0c, 0x52, 0x04, 0x64, 0x61, 0x74, 0x61, 0x22, 0xbf, 0x01, 0x0a, 0x0d, 0x42, 0x6c,
+	0x6f, 0x62, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x2a, 0x0a, 0x11, 0x62,
+	0x65, 0x61, 0x63, 0x6f, 0x6e, 0x5f, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x5f, 0x72, 0x6f, 0x6f, 0x74,
+	0x18, 0x01, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x0f, 0x62, 0x65, 0x61, 0x63, 0x6f, 0x6e, 0x42, 0x6c,
+	0x6f, 0x63, 0x6b, 0x52, 0x6f, 0x6f, 0x74, 0x12, 0x2a, 0x0a, 0x11, 0x62, 0x65, 0x61, 0x63, 0x6f,
+	0x6e, 0x5f, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x5f, 0x73, 0x6c, 0x6f, 0x74, 0x18, 0x02, 0x20, 0x01,
+	0x28, 0x04, 0x52, 0x0f, 0x62, 0x65, 0x61, 0x63, 0x6f, 0x6e, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x53,
+	0x6c, 0x6f, 0x74, 0x12, 0x2b, 0x0a, 0x05, 0x62, 0x6c, 0x6f, 0x62, 0x73, 0x18, 0x03, 0x20, 0x03,
+	0x28, 0x0b, 0x32, 0x15, 0x2e, 0x65, 0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d, 0x2e, 0x65, 0x74,
+	0x68, 0x2e, 0x76, 0x31, 0x2e, 0x42, 0x6c, 0x6f, 0x62, 0x52, 0x05, 0x62, 0x6c, 0x6f, 0x62, 0x73,
+	0x12, 0x29, 0x0a, 0x10, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x70,
+	0x72, 0x6f, 0x6f, 0x66, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x0f, 0x61, 0x67, 0x67, 0x72,
+	0x65, 0x67, 0x61, 0x74, 0x65, 0x64, 0x50, 0x72, 0x6f, 0x6f, 0x66, 0x42, 0x7a, 0x0a, 0x13, 0x6f,
+	0x72, 0x67, 0x2e, 0x65, 0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d, 0x2e, 0x65, 0x74, 0x68, 0x2e,
+	0x76, 0x31, 0x42, 0x10, 0x42, 0x65, 0x61, 0x63, 0x6f, 0x6e, 0x43, 0x68, 0x61, 0x69, 0x6e, 0x50,
+	0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a, 0x2b, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63,
+	0x6f, 0x6d, 0x2f, 0x70, 0x72, 0x79, 0x73, 0x6d, 0x61, 0x74, 0x69, 0x63, 0x6c, 0x61, 0x62, 0x73,
+	0x2f, 0x70, 0x72, 0x79, 0x73, 0x6d, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x65, 0x74, 0x68,
+	0x2f, 0x76, 0x31, 0xaa, 0x02, 0x0f, 0x45, 0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d, 0x2e, 0x45,
+	0x74, 0x68, 0x2e, 0x56, 0x31, 0xca, 0x02, 0x0f, 0x45, 0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d,
+	0x5c, 0x45, 0x74, 0x68, 0x5c, 0x76, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -2552,7 +2733,7 @@ func file_proto_eth_v1_beacon_chain_proto_rawDescGZIP() []byte {
 	return file_proto_eth_v1_beacon_chain_proto_rawDescData
 }
 
-var file_proto_eth_v1_beacon_chain_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
+var file_proto_eth_v1_beacon_chain_proto_msgTypes = make([]protoimpl.MessageInfo, 45)
 var file_proto_eth_v1_beacon_chain_proto_goTypes = []interface{}{
 	(*GenesisResponse)(nil),                                         // 0: ethereum.eth.v1.GenesisResponse
 	(*StateRequest)(nil),                                            // 1: ethereum.eth.v1.StateRequest
@@ -2592,60 +2773,64 @@ var file_proto_eth_v1_beacon_chain_proto_goTypes = []interface{}{
 	(*DepositContract)(nil),                                         // 35: ethereum.eth.v1.DepositContract
 	(*WeakSubjectivityResponse)(nil),                                // 36: ethereum.eth.v1.WeakSubjectivityResponse
 	(*WeakSubjectivityData)(nil),                                    // 37: ethereum.eth.v1.WeakSubjectivityData
-	(*GenesisResponse_Genesis)(nil),                                 // 38: ethereum.eth.v1.GenesisResponse.Genesis
-	(*StateRootResponse_StateRoot)(nil),                             // 39: ethereum.eth.v1.StateRootResponse.StateRoot
-	(*StateFinalityCheckpointResponse_StateFinalityCheckpoint)(nil), // 40: ethereum.eth.v1.StateFinalityCheckpointResponse.StateFinalityCheckpoint
-	nil,                           // 41: ethereum.eth.v1.SpecResponse.DataEntry
-	(*Fork)(nil),                  // 42: ethereum.eth.v1.Fork
-	(ValidatorStatus)(0),          // 43: ethereum.eth.v1.ValidatorStatus
-	(*ValidatorContainer)(nil),    // 44: ethereum.eth.v1.ValidatorContainer
-	(*Committee)(nil),             // 45: ethereum.eth.v1.Committee
-	(*Attestation)(nil),           // 46: ethereum.eth.v1.Attestation
-	(*BeaconBlockHeader)(nil),     // 47: ethereum.eth.v1.BeaconBlockHeader
-	(*BeaconBlock)(nil),           // 48: ethereum.eth.v1.BeaconBlock
-	(*AttesterSlashing)(nil),      // 49: ethereum.eth.v1.AttesterSlashing
-	(*ProposerSlashing)(nil),      // 50: ethereum.eth.v1.ProposerSlashing
-	(*SignedVoluntaryExit)(nil),   // 51: ethereum.eth.v1.SignedVoluntaryExit
-	(*Checkpoint)(nil),            // 52: ethereum.eth.v1.Checkpoint
-	(*timestamppb.Timestamp)(nil), // 53: google.protobuf.Timestamp
+	(*BlobsRequest)(nil),                                            // 38: ethereum.eth.v1.BlobsRequest
+	(*Blob)(nil),                                                    // 39: ethereum.eth.v1.Blob
+	(*BlobsResponse)(nil),                                           // 40: ethereum.eth.v1.BlobsResponse
+	(*GenesisResponse_Genesis)(nil),                                 // 41: ethereum.eth.v1.GenesisResponse.Genesis
+	(*StateRootResponse_StateRoot)(nil),                             // 42: ethereum.eth.v1.StateRootResponse.StateRoot
+	(*StateFinalityCheckpointResponse_StateFinalityCheckpoint)(nil), // 43: ethereum.eth.v1.StateFinalityCheckpointResponse.StateFinalityCheckpoint
+	nil,                           // 44: ethereum.eth.v1.SpecResponse.DataEntry
+	(*Fork)(nil),                  // 45: ethereum.eth.v1.Fork
+	(ValidatorStatus)(0),          // 46: ethereum.eth.v1.ValidatorStatus
+	(*ValidatorContainer)(nil),    // 47: ethereum.eth.v1.ValidatorContainer
+	(*Committee)(nil),             // 48: ethereum.eth.v1.Committee
+	(*Attestation)(nil),           // 49: ethereum.eth.v1.Attestation
+	(*BeaconBlockHeader)(nil),     // 50: ethereum.eth.v1.BeaconBlockHeader
+	(*BeaconBlock)(nil),           // 51: ethereum.eth.v1.BeaconBlock
+	(*AttesterSlashing)(nil),      // 52: ethereum.eth.v1.AttesterSlashing
+	(*ProposerSlashing)(nil),      // 53: ethereum.eth.v1.ProposerSlashing
+	(*SignedVoluntaryExit)(nil),   // 54: ethereum.eth.v1.SignedVoluntaryExit
+	(*Checkpoint)(nil),            // 55: ethereum.eth.v1.Checkpoint
+	(*timestamppb.Timestamp)(nil), // 56: google.protobuf.Timestamp
 }
 var file_proto_eth_v1_beacon_chain_proto_depIdxs = []int32{
-	38, // 0: ethereum.eth.v1.GenesisResponse.data:type_name -> ethereum.eth.v1.GenesisResponse.Genesis
-	39, // 1: ethereum.eth.v1.StateRootResponse.data:type_name -> ethereum.eth.v1.StateRootResponse.StateRoot
-	42, // 2: ethereum.eth.v1.StateForkResponse.data:type_name -> ethereum.eth.v1.Fork
-	40, // 3: ethereum.eth.v1.StateFinalityCheckpointResponse.data:type_name -> ethereum.eth.v1.StateFinalityCheckpointResponse.StateFinalityCheckpoint
-	43, // 4: ethereum.eth.v1.StateValidatorsRequest.status:type_name -> ethereum.eth.v1.ValidatorStatus
-	44, // 5: ethereum.eth.v1.StateValidatorsResponse.data:type_name -> ethereum.eth.v1.ValidatorContainer
+	41, // 0: ethereum.eth.v1.GenesisResponse.data:type_name -> ethereum.eth.v1.GenesisResponse.Genesis
+	42, // 1: ethereum.eth.v1.StateRootResponse.data:type_name -> ethereum.eth.v1.StateRootResponse.StateRoot
+	45, // 2: ethereum.eth.v1.StateForkResponse.data:type_name -> ethereum.eth.v1.Fork
+	43, // 3: ethereum.eth.v1.StateFinalityCheckpointResponse.data:type_name -> ethereum.eth.v1.StateFinalityCheckpointResponse.StateFinalityCheckpoint
+	46, // 4: ethereum.eth.v1.StateValidatorsRequest.status:type_name -> ethereum.eth.v1.ValidatorStatus
+	47, // 5: ethereum.eth.v1.StateValidatorsResponse.data:type_name -> ethereum.eth.v1.ValidatorContainer
 	9,  // 6: ethereum.eth.v1.ValidatorBalancesResponse.data:type_name -> ethereum.eth.v1.ValidatorBalance
-	44, // 7: ethereum.eth.v1.StateValidatorResponse.data:type_name -> ethereum.eth.v1.ValidatorContainer
-	45, // 8: ethereum.eth.v1.StateCommitteesResponse.data:type_name -> ethereum.eth.v1.Committee
-	46, // 9: ethereum.eth.v1.BlockAttestationsResponse.data:type_name -> ethereum.eth.v1.Attestation
+	47, // 7: ethereum.eth.v1.StateValidatorResponse.data:type_name -> ethereum.eth.v1.ValidatorContainer
+	48, // 8: ethereum.eth.v1.StateCommitteesResponse.data:type_name -> ethereum.eth.v1.Committee
+	49, // 9: ethereum.eth.v1.BlockAttestationsResponse.data:type_name -> ethereum.eth.v1.Attestation
 	15, // 10: ethereum.eth.v1.BlockRootResponse.data:type_name -> ethereum.eth.v1.BlockRootContainer
 	21, // 11: ethereum.eth.v1.BlockHeadersResponse.data:type_name -> ethereum.eth.v1.BlockHeaderContainer
 	21, // 12: ethereum.eth.v1.BlockHeaderResponse.data:type_name -> ethereum.eth.v1.BlockHeaderContainer
 	22, // 13: ethereum.eth.v1.BlockHeaderContainer.header:type_name -> ethereum.eth.v1.BeaconBlockHeaderContainer
-	47, // 14: ethereum.eth.v1.BeaconBlockHeaderContainer.message:type_name -> ethereum.eth.v1.BeaconBlockHeader
+	50, // 14: ethereum.eth.v1.BeaconBlockHeaderContainer.message:type_name -> ethereum.eth.v1.BeaconBlockHeader
 	25, // 15: ethereum.eth.v1.BlockResponse.data:type_name -> ethereum.eth.v1.BeaconBlockContainer
-	48, // 16: ethereum.eth.v1.BeaconBlockContainer.message:type_name -> ethereum.eth.v1.BeaconBlock
-	46, // 17: ethereum.eth.v1.SubmitAttestationsRequest.data:type_name -> ethereum.eth.v1.Attestation
-	46, // 18: ethereum.eth.v1.AttestationsPoolResponse.data:type_name -> ethereum.eth.v1.Attestation
-	49, // 19: ethereum.eth.v1.AttesterSlashingsPoolResponse.data:type_name -> ethereum.eth.v1.AttesterSlashing
-	50, // 20: ethereum.eth.v1.ProposerSlashingPoolResponse.data:type_name -> ethereum.eth.v1.ProposerSlashing
-	51, // 21: ethereum.eth.v1.VoluntaryExitsPoolResponse.data:type_name -> ethereum.eth.v1.SignedVoluntaryExit
-	42, // 22: ethereum.eth.v1.ForkScheduleResponse.data:type_name -> ethereum.eth.v1.Fork
-	41, // 23: ethereum.eth.v1.SpecResponse.data:type_name -> ethereum.eth.v1.SpecResponse.DataEntry
+	51, // 16: ethereum.eth.v1.BeaconBlockContainer.message:type_name -> ethereum.eth.v1.BeaconBlock
+	49, // 17: ethereum.eth.v1.SubmitAttestationsRequest.data:type_name -> ethereum.eth.v1.Attestation
+	49, // 18: ethereum.eth.v1.AttestationsPoolResponse.data:type_name -> ethereum.eth.v1.Attestation
+	52, // 19: ethereum.eth.v1.AttesterSlashingsPoolResponse.data:type_name -> ethereum.eth.v1.AttesterSlashing
+	53, // 20: ethereum.eth.v1.ProposerSlashingPoolResponse.data:type_name -> ethereum.eth.v1.ProposerSlashing
+	54, // 21: ethereum.eth.v1.VoluntaryExitsPoolResponse.data:type_name -> ethereum.eth.v1.SignedVoluntaryExit
+	45, // 22: ethereum.eth.v1.ForkScheduleResponse.data:type_name -> ethereum.eth.v1.Fork
+	44, // 23: ethereum.eth.v1.SpecResponse.data:type_name -> ethereum.eth.v1.SpecResponse.DataEntry
 	35, // 24: ethereum.eth.v1.DepositContractResponse.data:type_name -> ethereum.eth.v1.DepositContract
 	37, // 25: ethereum.eth.v1.WeakSubjectivityResponse.data:type_name -> ethereum.eth.v1.WeakSubjectivityData
-	52, // 26: ethereum.eth.v1.WeakSubjectivityData.ws_checkpoint:type_name -> ethereum.eth.v1.Checkpoint
-	53, // 27: ethereum.eth.v1.GenesisResponse.Genesis.genesis_time:type_name -> google.protobuf.Timestamp
-	52, // 28: ethereum.eth.v1.StateFinalityCheckpointResponse.StateFinalityCheckpoint.previous_justified:type_name -> ethereum.eth.v1.Checkpoint
-	52, // 29: ethereum.eth.v1.StateFinalityCheckpointResponse.StateFinalityCheckpoint.current_justified:type_name -> ethereum.eth.v1.Checkpoint
-	52, // 30: ethereum.eth.v1.StateFinalityCheckpointResponse.StateFinalityCheckpoint.finalized:type_name -> ethereum.eth.v1.Checkpoint
-	31, // [31:31] is the sub-list for method output_type
-	31, // [31:31] is the sub-list for method input_type
-	31, // [31:31] is the sub-list for extension type_name
-	31, // [31:31] is the sub-list for extension extendee
-	0,  // [0:31] is the sub-list for field type_name
+	55, // 26: ethereum.eth.v1.WeakSubjectivityData.ws_checkpoint:type_name -> ethereum.eth.v1.Checkpoint
+	39, // 27: ethereum.eth.v1.BlobsResponse.blobs:type_name -> ethereum.eth.v1.Blob
+	56, // 28: ethereum.eth.v1.GenesisResponse.Genesis.genesis_time:type_name -> google.protobuf.Timestamp
+	55, // 29: ethereum.eth.v1.StateFinalityCheckpointResponse.StateFinalityCheckpoint.previous_justified:type_name -> ethereum.eth.v1.Checkpoint
+	55, // 30: ethereum.eth.v1.StateFinalityCheckpointResponse.StateFinalityCheckpoint.current_justified:type_name -> ethereum.eth.v1.Checkpoint
+	55, // 31: ethereum.eth.v1.StateFinalityCheckpointResponse.StateFinalityCheckpoint.finalized:type_name -> ethereum.eth.v1.Checkpoint
+	32, // [32:32] is the sub-list for method output_type
+	32, // [32:32] is the sub-list for method input_type
+	32, // [32:32] is the sub-list for extension type_name
+	32, // [32:32] is the sub-list for extension extendee
+	0,  // [0:32] is the sub-list for field type_name
 }
 
 func init() { file_proto_eth_v1_beacon_chain_proto_init() }
@@ -3115,7 +3300,7 @@ func file_proto_eth_v1_beacon_chain_proto_init() {
 			}
 		}
 		file_proto_eth_v1_beacon_chain_proto_msgTypes[38].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*GenesisResponse_Genesis); i {
+			switch v := v.(*BlobsRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -3127,7 +3312,7 @@ func file_proto_eth_v1_beacon_chain_proto_init() {
 			}
 		}
 		file_proto_eth_v1_beacon_chain_proto_msgTypes[39].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*StateRootResponse_StateRoot); i {
+			switch v := v.(*Blob); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -3139,6 +3324,42 @@ func file_proto_eth_v1_beacon_chain_proto_init() {
 			}
 		}
 		file_proto_eth_v1_beacon_chain_proto_msgTypes[40].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*BlobsResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_proto_eth_v1_beacon_chain_proto_msgTypes[41].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*GenesisResponse_Genesis); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_proto_eth_v1_beacon_chain_proto_msgTypes[42].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*StateRootResponse_StateRoot); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_proto_eth_v1_beacon_chain_proto_msgTypes[43].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*StateFinalityCheckpointResponse_StateFinalityCheckpoint); i {
 			case 0:
 				return &v.state
@@ -3160,7 +3381,7 @@ func file_proto_eth_v1_beacon_chain_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_proto_eth_v1_beacon_chain_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   42,
+			NumMessages:   45,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/eth/v1/beacon_chain.pb.gw.go
+++ b/proto/eth/v1/beacon_chain.pb.gw.go
@@ -1,3 +1,4 @@
 //go:build ignore
+// +build ignore
 
 package ignore

--- a/proto/eth/v1/beacon_chain.proto
+++ b/proto/eth/v1/beacon_chain.proto
@@ -290,3 +290,20 @@ message WeakSubjectivityData {
     ethereum.eth.v1.Checkpoint ws_checkpoint = 1;
     bytes state_root = 2;
 }
+
+message BlobsRequest {
+    // The block identifier. Can be one of: "head" (canonical head in node's view), "genesis",
+    // "finalized", <slot>, <hex encoded blockRoot with 0x prefix>.
+    bytes block_id = 1;
+}
+
+message Blob {
+    bytes data = 1;
+}
+
+message BlobsResponse {
+    bytes beacon_block_root = 1;
+    uint64 beacon_block_slot = 2;
+    repeated Blob blobs = 3;
+    bytes aggregated_proof = 4;
+}

--- a/proto/eth/v1/beacon_state.pb.gw.go
+++ b/proto/eth/v1/beacon_state.pb.gw.go
@@ -1,3 +1,4 @@
 //go:build ignore
+// +build ignore
 
 package ignore

--- a/proto/eth/v1/events.pb.gw.go
+++ b/proto/eth/v1/events.pb.gw.go
@@ -1,3 +1,4 @@
 //go:build ignore
+// +build ignore
 
 package ignore

--- a/proto/eth/v1/node.pb.gw.go
+++ b/proto/eth/v1/node.pb.gw.go
@@ -1,3 +1,4 @@
 //go:build ignore
+// +build ignore
 
 package ignore

--- a/proto/eth/v1/validator.pb.gw.go
+++ b/proto/eth/v1/validator.pb.gw.go
@@ -1,3 +1,4 @@
 //go:build ignore
+// +build ignore
 
 package ignore

--- a/proto/eth/v2/beacon_block.pb.gw.go
+++ b/proto/eth/v2/beacon_block.pb.gw.go
@@ -1,3 +1,4 @@
 //go:build ignore
+// +build ignore
 
 package ignore

--- a/proto/eth/v2/beacon_state.pb.gw.go
+++ b/proto/eth/v2/beacon_state.pb.gw.go
@@ -1,3 +1,4 @@
 //go:build ignore
+// +build ignore
 
 package ignore

--- a/proto/eth/v2/ssz.pb.gw.go
+++ b/proto/eth/v2/ssz.pb.gw.go
@@ -1,3 +1,4 @@
 //go:build ignore
+// +build ignore
 
 package ignore

--- a/proto/eth/v2/sync_committee.pb.gw.go
+++ b/proto/eth/v2/sync_committee.pb.gw.go
@@ -1,3 +1,4 @@
 //go:build ignore
+// +build ignore
 
 package ignore

--- a/proto/eth/v2/validator.pb.gw.go
+++ b/proto/eth/v2/validator.pb.gw.go
@@ -1,3 +1,4 @@
 //go:build ignore
+// +build ignore
 
 package ignore

--- a/proto/eth/v2/version.pb.gw.go
+++ b/proto/eth/v2/version.pb.gw.go
@@ -1,3 +1,4 @@
 //go:build ignore
+// +build ignore
 
 package ignore

--- a/proto/prysm/v1alpha1/attestation.pb.gw.go
+++ b/proto/prysm/v1alpha1/attestation.pb.gw.go
@@ -1,3 +1,4 @@
 //go:build ignore
+// +build ignore
 
 package ignore

--- a/proto/prysm/v1alpha1/beacon_block.pb.go
+++ b/proto/prysm/v1alpha1/beacon_block.pb.go
@@ -7,9 +7,9 @@
 package eth
 
 import (
-	v1 "github.com/prysmaticlabs/prysm/proto/engine/v1"
 	github_com_prysmaticlabs_go_bitfield "github.com/prysmaticlabs/go-bitfield"
 	github_com_prysmaticlabs_prysm_consensus_types_primitives "github.com/prysmaticlabs/prysm/consensus-types/primitives"
+	v1 "github.com/prysmaticlabs/prysm/proto/engine/v1"
 	_ "github.com/prysmaticlabs/prysm/proto/eth/ext"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"

--- a/proto/prysm/v1alpha1/beacon_block.pb.gw.go
+++ b/proto/prysm/v1alpha1/beacon_block.pb.gw.go
@@ -1,3 +1,4 @@
 //go:build ignore
+// +build ignore
 
 package ignore

--- a/proto/prysm/v1alpha1/beacon_state.pb.gw.go
+++ b/proto/prysm/v1alpha1/beacon_state.pb.gw.go
@@ -1,3 +1,4 @@
 //go:build ignore
+// +build ignore
 
 package ignore

--- a/proto/prysm/v1alpha1/finalized_block_root_container.pb.gw.go
+++ b/proto/prysm/v1alpha1/finalized_block_root_container.pb.gw.go
@@ -1,3 +1,4 @@
 //go:build ignore
+// +build ignore
 
 package ignore

--- a/proto/prysm/v1alpha1/p2p_messages.pb.gw.go
+++ b/proto/prysm/v1alpha1/p2p_messages.pb.gw.go
@@ -1,3 +1,4 @@
 //go:build ignore
+// +build ignore
 
 package ignore

--- a/proto/prysm/v1alpha1/powchain.pb.gw.go
+++ b/proto/prysm/v1alpha1/powchain.pb.gw.go
@@ -1,3 +1,4 @@
 //go:build ignore
+// +build ignore
 
 package ignore

--- a/proto/prysm/v1alpha1/sync_committee.pb.gw.go
+++ b/proto/prysm/v1alpha1/sync_committee.pb.gw.go
@@ -1,3 +1,4 @@
 //go:build ignore
+// +build ignore
 
 package ignore


### PR DESCRIPTION
This PR:
- Fixes some bazel issues; fix missing imports in bazel build files, and disabled some linting warnings in the sync package that stopped it from compiling.
- Define api protobuf types for serving blobs sidecar data, and update protobuf code (using the `./hack/update-go-pbs.sh` script)
- Implements a basic API to retrieve a blobs sidecar by beacon block root, slot or label.
- Implements the http gateway hacks to get the new grpc api endpoint also exposed in http api

Very experimental, didn't get to testing yet.

API endpoint: `/eth/v1/blobs/sidecar/{block_id}`

