### PR TITLE
EIP-4844 Blobs sidecar API endpoint (rebased)

### DIFF
--- a/beacon-chain/rpc/apimiddleware/custom_handlers.go
+++ b/beacon-chain/rpc/apimiddleware/custom_handlers.go
@@ -40,6 +40,14 @@ func handleGetBeaconStateSSZ(m *apimiddleware.ApiProxyMiddleware, endpoint apimi
 	return handleGetSSZ(m, endpoint, w, req, config)
 }
 
+func handleGetBlobsSidecarSSZ(m *apimiddleware.ApiProxyMiddleware, endpoint apimiddleware.Endpoint, w http.ResponseWriter, req *http.Request) (handled bool) {
+	config := sszConfig{
+		fileName:     "blobs_sidecar.ssz",
+		responseJson: &sszResponseJson{},
+	}
+	return handleGetSSZ(m, endpoint, w, req, config)
+}
+
 func handleGetBeaconBlockSSZ(m *apimiddleware.ApiProxyMiddleware, endpoint apimiddleware.Endpoint, w http.ResponseWriter, req *http.Request) (handled bool) {
 	config := sszConfig{
 		fileName:     "beacon_block.ssz",

--- a/beacon-chain/rpc/apimiddleware/endpoint_factory.go
+++ b/beacon-chain/rpc/apimiddleware/endpoint_factory.go
@@ -70,6 +70,7 @@ func (_ *BeaconEndpointFactory) Paths() []string {
 		"/eth/v1/validator/contribution_and_proofs",
 		"/eth/v1/validator/prepare_beacon_proposer",
 		"/eth/v1/validator/register_validator",
+		"/eth/v1/blobs/sidecar/{block_id}",
 	}
 }
 
@@ -122,6 +123,12 @@ func (_ *BeaconEndpointFactory) Create(path string) (*apimiddleware.Endpoint, er
 	case "/eth/v1/beacon/blocks/{block_id}":
 		endpoint.GetResponse = &blockResponseJson{}
 		endpoint.CustomHandlers = []apimiddleware.CustomHandler{handleGetBeaconBlockSSZ}
+	case "/eth/v1/blobs/sidecar/{block_id}":
+		endpoint.GetResponse = &blobsSidecarResponseJson{}
+		endpoint.CustomHandlers = []apimiddleware.CustomHandler{handleGetBlobsSidecarSSZ}
+		endpoint.Hooks = apimiddleware.HookCollection{
+			OnPreDeserializeGrpcResponseBodyIntoContainer: prepareBlobsResponse,
+		}
 	case "/eth/v2/beacon/blocks/{block_id}":
 		endpoint.GetResponse = &blockV2ResponseJson{}
 		endpoint.Hooks = apimiddleware.HookCollection{

--- a/beacon-chain/rpc/apimiddleware/structs.go
+++ b/beacon-chain/rpc/apimiddleware/structs.go
@@ -1008,3 +1008,15 @@ type eventErrorJson struct {
 	StatusCode int    `json:"status_code"`
 	Message    string `json:"message"`
 }
+
+// 4844
+type blobsSidecarJson struct {
+	BeaconBlockRoot string   `json:"beacon_block_root" hex:"true"`
+	BeaconBlockSlot string   `json:"beacon_block_slot"`
+	Blobs           []string `json:"blobs" hex:"true"`
+	AggregatedProof string   `json:"kzg_aggregated_proof" hex:"true"`
+}
+
+type blobsSidecarResponseJson struct {
+	Data *blobsSidecarJson `json:"data"`
+}

--- a/beacon-chain/rpc/eth/beacon/BUILD.bazel
+++ b/beacon-chain/rpc/eth/beacon/BUILD.bazel
@@ -3,6 +3,7 @@ load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "blobs.go",
         "blocks.go",
         "config.go",
         "log.go",

--- a/beacon-chain/rpc/eth/beacon/blobs.go
+++ b/beacon-chain/rpc/eth/beacon/blobs.go
@@ -1,0 +1,39 @@
+package beacon
+
+import (
+	"context"
+	"fmt"
+	"github.com/pkg/errors"
+	ethpbv1 "github.com/prysmaticlabs/prysm/proto/eth/v1"
+)
+
+func (bs *Server) GetBlobsSidecar(ctx context.Context, req *ethpbv1.BlobsRequest) (*ethpbv1.BlobsResponse, error) {
+	blk, err := bs.blockFromBlockID(ctx, req.BlockId)
+	err = handleGetBlockError(blk, err)
+	if err != nil {
+		return nil, errors.Wrap(err, "GetBlobs")
+	}
+	root, err := blk.Block().HashTreeRoot()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to htr block")
+	}
+	sidecar, err := bs.BeaconDB.BlobsSidecar(ctx, root)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get blobs sidecar for block %x", root)
+	}
+	var blobs []*ethpbv1.Blob
+	for _, b := range sidecar.Blobs {
+		var data []byte
+		// go through each element, concat them
+		for _, el := range b.Blob {
+			data = append(data, el...)
+		}
+		blobs = append(blobs, &ethpbv1.Blob{Data: data})
+	}
+	return &ethpbv1.BlobsResponse{
+		BeaconBlockRoot: sidecar.BeaconBlockRoot,
+		BeaconBlockSlot: uint64(sidecar.BeaconBlockSlot),
+		Blobs:           blobs,
+		AggregatedProof: sidecar.AggregatedProof,
+	}, nil
+}

--- a/beacon-chain/rpc/eth/beacon/blobs.go
+++ b/beacon-chain/rpc/eth/beacon/blobs.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/pkg/errors"
-	ethpbv1 "github.com/prysmaticlabs/prysm/proto/eth/v1"
+	ethpbv1 "github.com/prysmaticlabs/prysm/v3/proto/eth/v1"
 )
 
 func (bs *Server) GetBlobsSidecar(ctx context.Context, req *ethpbv1.BlobsRequest) (*ethpbv1.BlobsResponse, error) {

--- a/beacon-chain/sync/initial-sync/BUILD.bazel
+++ b/beacon-chain/sync/initial-sync/BUILD.bazel
@@ -26,6 +26,8 @@ go_library(
         "//beacon-chain/core/transition:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/p2p:go_default_library",
+        "//beacon-chain/core/blob:go_default_library",
+        "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/p2p/peers/scorers:go_default_library",
         "//beacon-chain/p2p/types:go_default_library",
         "//beacon-chain/sync:go_default_library",

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/emicklei/dot v0.11.0
 	github.com/ethereum/go-ethereum v1.10.23
-	github.com/ferranbt/fastssz v0.0.0-20210526181520-7df50c8568f8
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5
 	github.com/fsnotify/fsnotify v1.5.4
 	github.com/ghodss/yaml v1.0.0
@@ -125,6 +124,7 @@ require (
 	github.com/dop251/goja v0.0.0-20220405120441-9037c2b61cbf // indirect
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/elastic/gosigar v0.14.2 // indirect
+	github.com/ferranbt/fastssz v0.0.0-20210526181520-7df50c8568f8 // indirect
 	github.com/flynn/noise v1.0.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect

--- a/nogo_config.json
+++ b/nogo_config.json
@@ -180,8 +180,7 @@
       ".*\\.pb.*.go": "Generated code is ok",
       ".*generated\\.ssz\\.go": "Generated code is ok",
       ".*_test\\.go": "Tests are ok (for now)",
-      "tools/analyzers/ineffassign/ineffassign\\.go": "3rd party code with a massive switch statement",
-      "beacon-chain/sync/.*": "experimentation"
+      "tools/analyzers/ineffassign/ineffassign\\.go": "3rd party code with a massive switch statement"
     }
   }
 }

--- a/nogo_config.json
+++ b/nogo_config.json
@@ -180,7 +180,8 @@
       ".*\\.pb.*.go": "Generated code is ok",
       ".*generated\\.ssz\\.go": "Generated code is ok",
       ".*_test\\.go": "Tests are ok (for now)",
-      "tools/analyzers/ineffassign/ineffassign\\.go": "3rd party code with a massive switch statement"
+      "tools/analyzers/ineffassign/ineffassign\\.go": "3rd party code with a massive switch statement",
+      "beacon-chain/sync/.*": "experimentation"
     }
   }
 }

--- a/proto/eth/service/beacon_chain_service.pb.go
+++ b/proto/eth/service/beacon_chain_service.pb.go
@@ -51,7 +51,7 @@ var file_proto_eth_service_beacon_chain_service_proto_rawDesc = []byte{
 	0x76, 0x32, 0x2f, 0x73, 0x73, 0x7a, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x21, 0x70, 0x72,
 	0x6f, 0x74, 0x6f, 0x2f, 0x65, 0x74, 0x68, 0x2f, 0x76, 0x32, 0x2f, 0x73, 0x79, 0x6e, 0x63, 0x5f,
 	0x63, 0x6f, 0x6d, 0x6d, 0x69, 0x74, 0x74, 0x65, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x32,
-	0x84, 0x27, 0x0a, 0x0b, 0x42, 0x65, 0x61, 0x63, 0x6f, 0x6e, 0x43, 0x68, 0x61, 0x69, 0x6e, 0x12,
+	0xfe, 0x27, 0x0a, 0x0b, 0x42, 0x65, 0x61, 0x63, 0x6f, 0x6e, 0x43, 0x68, 0x61, 0x69, 0x6e, 0x12,
 	0x6f, 0x0a, 0x0a, 0x47, 0x65, 0x74, 0x47, 0x65, 0x6e, 0x65, 0x73, 0x69, 0x73, 0x12, 0x16, 0x2e,
 	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
 	0x45, 0x6d, 0x70, 0x74, 0x79, 0x1a, 0x20, 0x2e, 0x65, 0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d,
@@ -363,17 +363,25 @@ var file_proto_eth_service_beacon_chain_service_proto_rawDesc = []byte{
 	0x6f, 0x6e, 0x73, 0x65, 0x22, 0x30, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x2a, 0x12, 0x28, 0x2f, 0x69,
 	0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c, 0x2f, 0x65, 0x74, 0x68, 0x2f, 0x76, 0x31, 0x2f, 0x63,
 	0x6f, 0x6e, 0x66, 0x69, 0x67, 0x2f, 0x64, 0x65, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x5f, 0x63, 0x6f,
-	0x6e, 0x74, 0x72, 0x61, 0x63, 0x74, 0x42, 0x98, 0x01, 0x0a, 0x18, 0x6f, 0x72, 0x67, 0x2e, 0x65,
-	0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d, 0x2e, 0x65, 0x74, 0x68, 0x2e, 0x73, 0x65, 0x72, 0x76,
-	0x69, 0x63, 0x65, 0x42, 0x17, 0x42, 0x65, 0x61, 0x63, 0x6f, 0x6e, 0x43, 0x68, 0x61, 0x69, 0x6e,
-	0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a, 0x33,
-	0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x70, 0x72, 0x79, 0x73, 0x6d,
-	0x61, 0x74, 0x69, 0x63, 0x6c, 0x61, 0x62, 0x73, 0x2f, 0x70, 0x72, 0x79, 0x73, 0x6d, 0x2f, 0x76,
-	0x33, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x65, 0x74, 0x68, 0x2f, 0x73, 0x65, 0x72, 0x76,
-	0x69, 0x63, 0x65, 0xaa, 0x02, 0x14, 0x45, 0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d, 0x2e, 0x45,
-	0x74, 0x68, 0x2e, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0xca, 0x02, 0x14, 0x45, 0x74, 0x68,
-	0x65, 0x72, 0x65, 0x75, 0x6d, 0x5c, 0x45, 0x74, 0x68, 0x5c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63,
-	0x65, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x6e, 0x74, 0x72, 0x61, 0x63, 0x74, 0x12, 0x78, 0x0a, 0x0f, 0x47, 0x65, 0x74, 0x42, 0x6c, 0x6f,
+	0x62, 0x73, 0x53, 0x69, 0x64, 0x65, 0x63, 0x61, 0x72, 0x12, 0x1d, 0x2e, 0x65, 0x74, 0x68, 0x65,
+	0x72, 0x65, 0x75, 0x6d, 0x2e, 0x65, 0x74, 0x68, 0x2e, 0x76, 0x31, 0x2e, 0x42, 0x6c, 0x6f, 0x62,
+	0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x1e, 0x2e, 0x65, 0x74, 0x68, 0x65, 0x72,
+	0x65, 0x75, 0x6d, 0x2e, 0x65, 0x74, 0x68, 0x2e, 0x76, 0x31, 0x2e, 0x42, 0x6c, 0x6f, 0x62, 0x73,
+	0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x26, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x20,
+	0x12, 0x1e, 0x2f, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c, 0x2f, 0x65, 0x74, 0x68, 0x2f,
+	0x76, 0x31, 0x2f, 0x62, 0x6c, 0x6f, 0x62, 0x73, 0x2f, 0x73, 0x69, 0x64, 0x65, 0x63, 0x61, 0x72,
+	0x42, 0x98, 0x01, 0x0a, 0x18, 0x6f, 0x72, 0x67, 0x2e, 0x65, 0x74, 0x68, 0x65, 0x72, 0x65, 0x75,
+	0x6d, 0x2e, 0x65, 0x74, 0x68, 0x2e, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x42, 0x17, 0x42,
+	0x65, 0x61, 0x63, 0x6f, 0x6e, 0x43, 0x68, 0x61, 0x69, 0x6e, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63,
+	0x65, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a, 0x33, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62,
+	0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x70, 0x72, 0x79, 0x73, 0x6d, 0x61, 0x74, 0x69, 0x63, 0x6c, 0x61,
+	0x62, 0x73, 0x2f, 0x70, 0x72, 0x79, 0x73, 0x6d, 0x2f, 0x76, 0x33, 0x2f, 0x70, 0x72, 0x6f, 0x74,
+	0x6f, 0x2f, 0x65, 0x74, 0x68, 0x2f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0xaa, 0x02, 0x14,
+	0x45, 0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d, 0x2e, 0x45, 0x74, 0x68, 0x2e, 0x53, 0x65, 0x72,
+	0x76, 0x69, 0x63, 0x65, 0xca, 0x02, 0x14, 0x45, 0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d, 0x5c,
+	0x45, 0x74, 0x68, 0x5c, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x62, 0x06, 0x70, 0x72, 0x6f,
+	0x74, 0x6f, 0x33,
 }
 
 var file_proto_eth_service_beacon_chain_service_proto_goTypes = []interface{}{
@@ -396,30 +404,32 @@ var file_proto_eth_service_beacon_chain_service_proto_goTypes = []interface{}{
 	(*v1.ProposerSlashing)(nil),                  // 16: ethereum.eth.v1.ProposerSlashing
 	(*v1.SignedVoluntaryExit)(nil),               // 17: ethereum.eth.v1.SignedVoluntaryExit
 	(*v2.SubmitPoolSyncCommitteeSignatures)(nil), // 18: ethereum.eth.v2.SubmitPoolSyncCommitteeSignatures
-	(*v1.GenesisResponse)(nil),                   // 19: ethereum.eth.v1.GenesisResponse
-	(*v1.WeakSubjectivityResponse)(nil),          // 20: ethereum.eth.v1.WeakSubjectivityResponse
-	(*v1.StateRootResponse)(nil),                 // 21: ethereum.eth.v1.StateRootResponse
-	(*v1.StateForkResponse)(nil),                 // 22: ethereum.eth.v1.StateForkResponse
-	(*v1.StateFinalityCheckpointResponse)(nil),   // 23: ethereum.eth.v1.StateFinalityCheckpointResponse
-	(*v1.StateValidatorsResponse)(nil),           // 24: ethereum.eth.v1.StateValidatorsResponse
-	(*v1.StateValidatorResponse)(nil),            // 25: ethereum.eth.v1.StateValidatorResponse
-	(*v1.ValidatorBalancesResponse)(nil),         // 26: ethereum.eth.v1.ValidatorBalancesResponse
-	(*v1.StateCommitteesResponse)(nil),           // 27: ethereum.eth.v1.StateCommitteesResponse
-	(*v2.StateSyncCommitteesResponse)(nil),       // 28: ethereum.eth.v2.StateSyncCommitteesResponse
-	(*v1.BlockHeadersResponse)(nil),              // 29: ethereum.eth.v1.BlockHeadersResponse
-	(*v1.BlockHeaderResponse)(nil),               // 30: ethereum.eth.v1.BlockHeaderResponse
-	(*v1.BlockRootResponse)(nil),                 // 31: ethereum.eth.v1.BlockRootResponse
-	(*v1.BlockResponse)(nil),                     // 32: ethereum.eth.v1.BlockResponse
-	(*v1.BlockSSZResponse)(nil),                  // 33: ethereum.eth.v1.BlockSSZResponse
-	(*v2.BlockResponseV2)(nil),                   // 34: ethereum.eth.v2.BlockResponseV2
-	(*v1.BlockAttestationsResponse)(nil),         // 35: ethereum.eth.v1.BlockAttestationsResponse
-	(*v1.AttestationsPoolResponse)(nil),          // 36: ethereum.eth.v1.AttestationsPoolResponse
-	(*v1.AttesterSlashingsPoolResponse)(nil),     // 37: ethereum.eth.v1.AttesterSlashingsPoolResponse
-	(*v1.ProposerSlashingPoolResponse)(nil),      // 38: ethereum.eth.v1.ProposerSlashingPoolResponse
-	(*v1.VoluntaryExitsPoolResponse)(nil),        // 39: ethereum.eth.v1.VoluntaryExitsPoolResponse
-	(*v1.ForkScheduleResponse)(nil),              // 40: ethereum.eth.v1.ForkScheduleResponse
-	(*v1.SpecResponse)(nil),                      // 41: ethereum.eth.v1.SpecResponse
-	(*v1.DepositContractResponse)(nil),           // 42: ethereum.eth.v1.DepositContractResponse
+	(*v1.BlobsRequest)(nil),                      // 19: ethereum.eth.v1.BlobsRequest
+	(*v1.GenesisResponse)(nil),                   // 20: ethereum.eth.v1.GenesisResponse
+	(*v1.WeakSubjectivityResponse)(nil),          // 21: ethereum.eth.v1.WeakSubjectivityResponse
+	(*v1.StateRootResponse)(nil),                 // 22: ethereum.eth.v1.StateRootResponse
+	(*v1.StateForkResponse)(nil),                 // 23: ethereum.eth.v1.StateForkResponse
+	(*v1.StateFinalityCheckpointResponse)(nil),   // 24: ethereum.eth.v1.StateFinalityCheckpointResponse
+	(*v1.StateValidatorsResponse)(nil),           // 25: ethereum.eth.v1.StateValidatorsResponse
+	(*v1.StateValidatorResponse)(nil),            // 26: ethereum.eth.v1.StateValidatorResponse
+	(*v1.ValidatorBalancesResponse)(nil),         // 27: ethereum.eth.v1.ValidatorBalancesResponse
+	(*v1.StateCommitteesResponse)(nil),           // 28: ethereum.eth.v1.StateCommitteesResponse
+	(*v2.StateSyncCommitteesResponse)(nil),       // 29: ethereum.eth.v2.StateSyncCommitteesResponse
+	(*v1.BlockHeadersResponse)(nil),              // 30: ethereum.eth.v1.BlockHeadersResponse
+	(*v1.BlockHeaderResponse)(nil),               // 31: ethereum.eth.v1.BlockHeaderResponse
+	(*v1.BlockRootResponse)(nil),                 // 32: ethereum.eth.v1.BlockRootResponse
+	(*v1.BlockResponse)(nil),                     // 33: ethereum.eth.v1.BlockResponse
+	(*v1.BlockSSZResponse)(nil),                  // 34: ethereum.eth.v1.BlockSSZResponse
+	(*v2.BlockResponseV2)(nil),                   // 35: ethereum.eth.v2.BlockResponseV2
+	(*v1.BlockAttestationsResponse)(nil),         // 36: ethereum.eth.v1.BlockAttestationsResponse
+	(*v1.AttestationsPoolResponse)(nil),          // 37: ethereum.eth.v1.AttestationsPoolResponse
+	(*v1.AttesterSlashingsPoolResponse)(nil),     // 38: ethereum.eth.v1.AttesterSlashingsPoolResponse
+	(*v1.ProposerSlashingPoolResponse)(nil),      // 39: ethereum.eth.v1.ProposerSlashingPoolResponse
+	(*v1.VoluntaryExitsPoolResponse)(nil),        // 40: ethereum.eth.v1.VoluntaryExitsPoolResponse
+	(*v1.ForkScheduleResponse)(nil),              // 41: ethereum.eth.v1.ForkScheduleResponse
+	(*v1.SpecResponse)(nil),                      // 42: ethereum.eth.v1.SpecResponse
+	(*v1.DepositContractResponse)(nil),           // 43: ethereum.eth.v1.DepositContractResponse
+	(*v1.BlobsResponse)(nil),                     // 44: ethereum.eth.v1.BlobsResponse
 }
 var file_proto_eth_service_beacon_chain_service_proto_depIdxs = []int32{
 	0,  // 0: ethereum.eth.service.BeaconChain.GetGenesis:input_type -> google.protobuf.Empty
@@ -456,42 +466,44 @@ var file_proto_eth_service_beacon_chain_service_proto_depIdxs = []int32{
 	0,  // 31: ethereum.eth.service.BeaconChain.GetForkSchedule:input_type -> google.protobuf.Empty
 	0,  // 32: ethereum.eth.service.BeaconChain.GetSpec:input_type -> google.protobuf.Empty
 	0,  // 33: ethereum.eth.service.BeaconChain.GetDepositContract:input_type -> google.protobuf.Empty
-	19, // 34: ethereum.eth.service.BeaconChain.GetGenesis:output_type -> ethereum.eth.v1.GenesisResponse
-	20, // 35: ethereum.eth.service.BeaconChain.GetWeakSubjectivity:output_type -> ethereum.eth.v1.WeakSubjectivityResponse
-	21, // 36: ethereum.eth.service.BeaconChain.GetStateRoot:output_type -> ethereum.eth.v1.StateRootResponse
-	22, // 37: ethereum.eth.service.BeaconChain.GetStateFork:output_type -> ethereum.eth.v1.StateForkResponse
-	23, // 38: ethereum.eth.service.BeaconChain.GetFinalityCheckpoints:output_type -> ethereum.eth.v1.StateFinalityCheckpointResponse
-	24, // 39: ethereum.eth.service.BeaconChain.ListValidators:output_type -> ethereum.eth.v1.StateValidatorsResponse
-	25, // 40: ethereum.eth.service.BeaconChain.GetValidator:output_type -> ethereum.eth.v1.StateValidatorResponse
-	26, // 41: ethereum.eth.service.BeaconChain.ListValidatorBalances:output_type -> ethereum.eth.v1.ValidatorBalancesResponse
-	27, // 42: ethereum.eth.service.BeaconChain.ListCommittees:output_type -> ethereum.eth.v1.StateCommitteesResponse
-	28, // 43: ethereum.eth.service.BeaconChain.ListSyncCommittees:output_type -> ethereum.eth.v2.StateSyncCommitteesResponse
-	29, // 44: ethereum.eth.service.BeaconChain.ListBlockHeaders:output_type -> ethereum.eth.v1.BlockHeadersResponse
-	30, // 45: ethereum.eth.service.BeaconChain.GetBlockHeader:output_type -> ethereum.eth.v1.BlockHeaderResponse
-	0,  // 46: ethereum.eth.service.BeaconChain.SubmitBlock:output_type -> google.protobuf.Empty
-	0,  // 47: ethereum.eth.service.BeaconChain.SubmitBlockSSZ:output_type -> google.protobuf.Empty
-	0,  // 48: ethereum.eth.service.BeaconChain.SubmitBlindedBlock:output_type -> google.protobuf.Empty
-	0,  // 49: ethereum.eth.service.BeaconChain.SubmitBlindedBlockSSZ:output_type -> google.protobuf.Empty
-	31, // 50: ethereum.eth.service.BeaconChain.GetBlockRoot:output_type -> ethereum.eth.v1.BlockRootResponse
-	32, // 51: ethereum.eth.service.BeaconChain.GetBlock:output_type -> ethereum.eth.v1.BlockResponse
-	33, // 52: ethereum.eth.service.BeaconChain.GetBlockSSZ:output_type -> ethereum.eth.v1.BlockSSZResponse
-	34, // 53: ethereum.eth.service.BeaconChain.GetBlockV2:output_type -> ethereum.eth.v2.BlockResponseV2
-	10, // 54: ethereum.eth.service.BeaconChain.GetBlockSSZV2:output_type -> ethereum.eth.v2.SSZContainer
-	35, // 55: ethereum.eth.service.BeaconChain.ListBlockAttestations:output_type -> ethereum.eth.v1.BlockAttestationsResponse
-	36, // 56: ethereum.eth.service.BeaconChain.ListPoolAttestations:output_type -> ethereum.eth.v1.AttestationsPoolResponse
-	0,  // 57: ethereum.eth.service.BeaconChain.SubmitAttestations:output_type -> google.protobuf.Empty
-	37, // 58: ethereum.eth.service.BeaconChain.ListPoolAttesterSlashings:output_type -> ethereum.eth.v1.AttesterSlashingsPoolResponse
-	0,  // 59: ethereum.eth.service.BeaconChain.SubmitAttesterSlashing:output_type -> google.protobuf.Empty
-	38, // 60: ethereum.eth.service.BeaconChain.ListPoolProposerSlashings:output_type -> ethereum.eth.v1.ProposerSlashingPoolResponse
-	0,  // 61: ethereum.eth.service.BeaconChain.SubmitProposerSlashing:output_type -> google.protobuf.Empty
-	39, // 62: ethereum.eth.service.BeaconChain.ListPoolVoluntaryExits:output_type -> ethereum.eth.v1.VoluntaryExitsPoolResponse
-	0,  // 63: ethereum.eth.service.BeaconChain.SubmitVoluntaryExit:output_type -> google.protobuf.Empty
-	0,  // 64: ethereum.eth.service.BeaconChain.SubmitPoolSyncCommitteeSignatures:output_type -> google.protobuf.Empty
-	40, // 65: ethereum.eth.service.BeaconChain.GetForkSchedule:output_type -> ethereum.eth.v1.ForkScheduleResponse
-	41, // 66: ethereum.eth.service.BeaconChain.GetSpec:output_type -> ethereum.eth.v1.SpecResponse
-	42, // 67: ethereum.eth.service.BeaconChain.GetDepositContract:output_type -> ethereum.eth.v1.DepositContractResponse
-	34, // [34:68] is the sub-list for method output_type
-	0,  // [0:34] is the sub-list for method input_type
+	19, // 34: ethereum.eth.service.BeaconChain.GetBlobsSidecar:input_type -> ethereum.eth.v1.BlobsRequest
+	20, // 35: ethereum.eth.service.BeaconChain.GetGenesis:output_type -> ethereum.eth.v1.GenesisResponse
+	21, // 36: ethereum.eth.service.BeaconChain.GetWeakSubjectivity:output_type -> ethereum.eth.v1.WeakSubjectivityResponse
+	22, // 37: ethereum.eth.service.BeaconChain.GetStateRoot:output_type -> ethereum.eth.v1.StateRootResponse
+	23, // 38: ethereum.eth.service.BeaconChain.GetStateFork:output_type -> ethereum.eth.v1.StateForkResponse
+	24, // 39: ethereum.eth.service.BeaconChain.GetFinalityCheckpoints:output_type -> ethereum.eth.v1.StateFinalityCheckpointResponse
+	25, // 40: ethereum.eth.service.BeaconChain.ListValidators:output_type -> ethereum.eth.v1.StateValidatorsResponse
+	26, // 41: ethereum.eth.service.BeaconChain.GetValidator:output_type -> ethereum.eth.v1.StateValidatorResponse
+	27, // 42: ethereum.eth.service.BeaconChain.ListValidatorBalances:output_type -> ethereum.eth.v1.ValidatorBalancesResponse
+	28, // 43: ethereum.eth.service.BeaconChain.ListCommittees:output_type -> ethereum.eth.v1.StateCommitteesResponse
+	29, // 44: ethereum.eth.service.BeaconChain.ListSyncCommittees:output_type -> ethereum.eth.v2.StateSyncCommitteesResponse
+	30, // 45: ethereum.eth.service.BeaconChain.ListBlockHeaders:output_type -> ethereum.eth.v1.BlockHeadersResponse
+	31, // 46: ethereum.eth.service.BeaconChain.GetBlockHeader:output_type -> ethereum.eth.v1.BlockHeaderResponse
+	0,  // 47: ethereum.eth.service.BeaconChain.SubmitBlock:output_type -> google.protobuf.Empty
+	0,  // 48: ethereum.eth.service.BeaconChain.SubmitBlockSSZ:output_type -> google.protobuf.Empty
+	0,  // 49: ethereum.eth.service.BeaconChain.SubmitBlindedBlock:output_type -> google.protobuf.Empty
+	0,  // 50: ethereum.eth.service.BeaconChain.SubmitBlindedBlockSSZ:output_type -> google.protobuf.Empty
+	32, // 51: ethereum.eth.service.BeaconChain.GetBlockRoot:output_type -> ethereum.eth.v1.BlockRootResponse
+	33, // 52: ethereum.eth.service.BeaconChain.GetBlock:output_type -> ethereum.eth.v1.BlockResponse
+	34, // 53: ethereum.eth.service.BeaconChain.GetBlockSSZ:output_type -> ethereum.eth.v1.BlockSSZResponse
+	35, // 54: ethereum.eth.service.BeaconChain.GetBlockV2:output_type -> ethereum.eth.v2.BlockResponseV2
+	10, // 55: ethereum.eth.service.BeaconChain.GetBlockSSZV2:output_type -> ethereum.eth.v2.SSZContainer
+	36, // 56: ethereum.eth.service.BeaconChain.ListBlockAttestations:output_type -> ethereum.eth.v1.BlockAttestationsResponse
+	37, // 57: ethereum.eth.service.BeaconChain.ListPoolAttestations:output_type -> ethereum.eth.v1.AttestationsPoolResponse
+	0,  // 58: ethereum.eth.service.BeaconChain.SubmitAttestations:output_type -> google.protobuf.Empty
+	38, // 59: ethereum.eth.service.BeaconChain.ListPoolAttesterSlashings:output_type -> ethereum.eth.v1.AttesterSlashingsPoolResponse
+	0,  // 60: ethereum.eth.service.BeaconChain.SubmitAttesterSlashing:output_type -> google.protobuf.Empty
+	39, // 61: ethereum.eth.service.BeaconChain.ListPoolProposerSlashings:output_type -> ethereum.eth.v1.ProposerSlashingPoolResponse
+	0,  // 62: ethereum.eth.service.BeaconChain.SubmitProposerSlashing:output_type -> google.protobuf.Empty
+	40, // 63: ethereum.eth.service.BeaconChain.ListPoolVoluntaryExits:output_type -> ethereum.eth.v1.VoluntaryExitsPoolResponse
+	0,  // 64: ethereum.eth.service.BeaconChain.SubmitVoluntaryExit:output_type -> google.protobuf.Empty
+	0,  // 65: ethereum.eth.service.BeaconChain.SubmitPoolSyncCommitteeSignatures:output_type -> google.protobuf.Empty
+	41, // 66: ethereum.eth.service.BeaconChain.GetForkSchedule:output_type -> ethereum.eth.v1.ForkScheduleResponse
+	42, // 67: ethereum.eth.service.BeaconChain.GetSpec:output_type -> ethereum.eth.v1.SpecResponse
+	43, // 68: ethereum.eth.service.BeaconChain.GetDepositContract:output_type -> ethereum.eth.v1.DepositContractResponse
+	44, // 69: ethereum.eth.service.BeaconChain.GetBlobsSidecar:output_type -> ethereum.eth.v1.BlobsResponse
+	35, // [35:70] is the sub-list for method output_type
+	0,  // [0:35] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name
@@ -567,6 +579,7 @@ type BeaconChainClient interface {
 	GetForkSchedule(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*v1.ForkScheduleResponse, error)
 	GetSpec(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*v1.SpecResponse, error)
 	GetDepositContract(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*v1.DepositContractResponse, error)
+	GetBlobsSidecar(ctx context.Context, in *v1.BlobsRequest, opts ...grpc.CallOption) (*v1.BlobsResponse, error)
 }
 
 type beaconChainClient struct {
@@ -883,6 +896,15 @@ func (c *beaconChainClient) GetDepositContract(ctx context.Context, in *empty.Em
 	return out, nil
 }
 
+func (c *beaconChainClient) GetBlobsSidecar(ctx context.Context, in *v1.BlobsRequest, opts ...grpc.CallOption) (*v1.BlobsResponse, error) {
+	out := new(v1.BlobsResponse)
+	err := c.cc.Invoke(ctx, "/ethereum.eth.service.BeaconChain/GetBlobsSidecar", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // BeaconChainServer is the server API for BeaconChain service.
 type BeaconChainServer interface {
 	GetGenesis(context.Context, *empty.Empty) (*v1.GenesisResponse, error)
@@ -919,6 +941,7 @@ type BeaconChainServer interface {
 	GetForkSchedule(context.Context, *empty.Empty) (*v1.ForkScheduleResponse, error)
 	GetSpec(context.Context, *empty.Empty) (*v1.SpecResponse, error)
 	GetDepositContract(context.Context, *empty.Empty) (*v1.DepositContractResponse, error)
+	GetBlobsSidecar(context.Context, *v1.BlobsRequest) (*v1.BlobsResponse, error)
 }
 
 // UnimplementedBeaconChainServer can be embedded to have forward compatible implementations.
@@ -1026,6 +1049,9 @@ func (*UnimplementedBeaconChainServer) GetSpec(context.Context, *empty.Empty) (*
 }
 func (*UnimplementedBeaconChainServer) GetDepositContract(context.Context, *empty.Empty) (*v1.DepositContractResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetDepositContract not implemented")
+}
+func (*UnimplementedBeaconChainServer) GetBlobsSidecar(context.Context, *v1.BlobsRequest) (*v1.BlobsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetBlobsSidecar not implemented")
 }
 
 func RegisterBeaconChainServer(s *grpc.Server, srv BeaconChainServer) {
@@ -1644,6 +1670,24 @@ func _BeaconChain_GetDepositContract_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _BeaconChain_GetBlobsSidecar_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(v1.BlobsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BeaconChainServer).GetBlobsSidecar(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/ethereum.eth.service.BeaconChain/GetBlobsSidecar",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BeaconChainServer).GetBlobsSidecar(ctx, req.(*v1.BlobsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _BeaconChain_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "ethereum.eth.service.BeaconChain",
 	HandlerType: (*BeaconChainServer)(nil),
@@ -1783,6 +1827,10 @@ var _BeaconChain_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetDepositContract",
 			Handler:    _BeaconChain_GetDepositContract_Handler,
+		},
+		{
+			MethodName: "GetBlobsSidecar",
+			Handler:    _BeaconChain_GetBlobsSidecar_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/proto/eth/service/beacon_chain_service.pb.gw.go
+++ b/proto/eth/service/beacon_chain_service.pb.gw.go
@@ -1464,6 +1464,42 @@ func local_request_BeaconChain_GetDepositContract_0(ctx context.Context, marshal
 
 }
 
+var (
+	filter_BeaconChain_GetBlobsSidecar_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+)
+
+func request_BeaconChain_GetBlobsSidecar_0(ctx context.Context, marshaler runtime.Marshaler, client BeaconChainClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq v1.BlobsRequest
+	var metadata runtime.ServerMetadata
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_BeaconChain_GetBlobsSidecar_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.GetBlobsSidecar(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_BeaconChain_GetBlobsSidecar_0(ctx context.Context, marshaler runtime.Marshaler, server BeaconChainServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq v1.BlobsRequest
+	var metadata runtime.ServerMetadata
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_BeaconChain_GetBlobsSidecar_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.GetBlobsSidecar(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 // RegisterBeaconChainHandlerServer registers the http handlers for service BeaconChain to "mux".
 // UnaryRPC     :call BeaconChainServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -2252,6 +2288,29 @@ func RegisterBeaconChainHandlerServer(ctx context.Context, mux *runtime.ServeMux
 
 	})
 
+	mux.Handle("GET", pattern_BeaconChain_GetBlobsSidecar_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/ethereum.eth.service.BeaconChain/GetBlobsSidecar")
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_BeaconChain_GetBlobsSidecar_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_BeaconChain_GetBlobsSidecar_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -2973,6 +3032,26 @@ func RegisterBeaconChainHandlerClient(ctx context.Context, mux *runtime.ServeMux
 
 	})
 
+	mux.Handle("GET", pattern_BeaconChain_GetBlobsSidecar_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req, "/ethereum.eth.service.BeaconChain/GetBlobsSidecar")
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_BeaconChain_GetBlobsSidecar_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_BeaconChain_GetBlobsSidecar_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -3044,6 +3123,8 @@ var (
 	pattern_BeaconChain_GetSpec_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"internal", "eth", "v1", "config", "spec"}, ""))
 
 	pattern_BeaconChain_GetDepositContract_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"internal", "eth", "v1", "config", "deposit_contract"}, ""))
+
+	pattern_BeaconChain_GetBlobsSidecar_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"internal", "eth", "v1", "blobs", "sidecar"}, ""))
 )
 
 var (
@@ -3114,4 +3195,6 @@ var (
 	forward_BeaconChain_GetSpec_0 = runtime.ForwardResponseMessage
 
 	forward_BeaconChain_GetDepositContract_0 = runtime.ForwardResponseMessage
+
+	forward_BeaconChain_GetBlobsSidecar_0 = runtime.ForwardResponseMessage
 )

--- a/proto/eth/service/beacon_chain_service.proto
+++ b/proto/eth/service/beacon_chain_service.proto
@@ -388,5 +388,10 @@ service BeaconChain {
   rpc GetDepositContract(google.protobuf.Empty) returns (v1.DepositContractResponse) {
     option (google.api.http) = {get: "/internal/eth/v1/config/deposit_contract"};
   }
+
+  // GetBlobs retrieves blob data by block ID and data hash
+  rpc GetBlobsSidecar(v1.BlobsRequest) returns (v1.BlobsResponse) {
+    option (google.api.http) = {get: "/internal/eth/v1/blobs/sidecar"};
+  }
 }
 

--- a/proto/eth/v1/beacon_chain.pb.go
+++ b/proto/eth/v1/beacon_chain.pb.go
@@ -2272,6 +2272,171 @@ func (x *ForkChoiceNode) GetTimestamp() uint64 {
 	return 0
 }
 
+type BlobsRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	BlockId []byte `protobuf:"bytes,1,opt,name=block_id,json=blockId,proto3" json:"block_id,omitempty"`
+}
+
+func (x *BlobsRequest) Reset() {
+	*x = BlobsRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[40]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *BlobsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BlobsRequest) ProtoMessage() {}
+
+func (x *BlobsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[40]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BlobsRequest.ProtoReflect.Descriptor instead.
+func (*BlobsRequest) Descriptor() ([]byte, []int) {
+	return file_proto_eth_v1_beacon_chain_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *BlobsRequest) GetBlockId() []byte {
+	if x != nil {
+		return x.BlockId
+	}
+	return nil
+}
+
+type Blob struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Data []byte `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
+}
+
+func (x *Blob) Reset() {
+	*x = Blob{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[41]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *Blob) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Blob) ProtoMessage() {}
+
+func (x *Blob) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[41]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Blob.ProtoReflect.Descriptor instead.
+func (*Blob) Descriptor() ([]byte, []int) {
+	return file_proto_eth_v1_beacon_chain_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *Blob) GetData() []byte {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
+type BlobsResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	BeaconBlockRoot []byte  `protobuf:"bytes,1,opt,name=beacon_block_root,json=beaconBlockRoot,proto3" json:"beacon_block_root,omitempty"`
+	BeaconBlockSlot uint64  `protobuf:"varint,2,opt,name=beacon_block_slot,json=beaconBlockSlot,proto3" json:"beacon_block_slot,omitempty"`
+	Blobs           []*Blob `protobuf:"bytes,3,rep,name=blobs,proto3" json:"blobs,omitempty"`
+	AggregatedProof []byte  `protobuf:"bytes,4,opt,name=aggregated_proof,json=aggregatedProof,proto3" json:"aggregated_proof,omitempty"`
+}
+
+func (x *BlobsResponse) Reset() {
+	*x = BlobsResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[42]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *BlobsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BlobsResponse) ProtoMessage() {}
+
+func (x *BlobsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[42]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BlobsResponse.ProtoReflect.Descriptor instead.
+func (*BlobsResponse) Descriptor() ([]byte, []int) {
+	return file_proto_eth_v1_beacon_chain_proto_rawDescGZIP(), []int{42}
+}
+
+func (x *BlobsResponse) GetBeaconBlockRoot() []byte {
+	if x != nil {
+		return x.BeaconBlockRoot
+	}
+	return nil
+}
+
+func (x *BlobsResponse) GetBeaconBlockSlot() uint64 {
+	if x != nil {
+		return x.BeaconBlockSlot
+	}
+	return 0
+}
+
+func (x *BlobsResponse) GetBlobs() []*Blob {
+	if x != nil {
+		return x.Blobs
+	}
+	return nil
+}
+
+func (x *BlobsResponse) GetAggregatedProof() []byte {
+	if x != nil {
+		return x.AggregatedProof
+	}
+	return nil
+}
+
 type GenesisResponse_Genesis struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2285,7 +2450,7 @@ type GenesisResponse_Genesis struct {
 func (x *GenesisResponse_Genesis) Reset() {
 	*x = GenesisResponse_Genesis{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[40]
+		mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[43]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2298,7 +2463,7 @@ func (x *GenesisResponse_Genesis) String() string {
 func (*GenesisResponse_Genesis) ProtoMessage() {}
 
 func (x *GenesisResponse_Genesis) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[40]
+	mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[43]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2346,7 +2511,7 @@ type StateRootResponse_StateRoot struct {
 func (x *StateRootResponse_StateRoot) Reset() {
 	*x = StateRootResponse_StateRoot{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[41]
+		mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[44]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2359,7 +2524,7 @@ func (x *StateRootResponse_StateRoot) String() string {
 func (*StateRootResponse_StateRoot) ProtoMessage() {}
 
 func (x *StateRootResponse_StateRoot) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[41]
+	mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[44]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2395,7 +2560,7 @@ type StateFinalityCheckpointResponse_StateFinalityCheckpoint struct {
 func (x *StateFinalityCheckpointResponse_StateFinalityCheckpoint) Reset() {
 	*x = StateFinalityCheckpointResponse_StateFinalityCheckpoint{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[42]
+		mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[45]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2408,7 +2573,7 @@ func (x *StateFinalityCheckpointResponse_StateFinalityCheckpoint) String() strin
 func (*StateFinalityCheckpointResponse_StateFinalityCheckpoint) ProtoMessage() {}
 
 func (x *StateFinalityCheckpointResponse_StateFinalityCheckpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[42]
+	mi := &file_proto_eth_v1_beacon_chain_proto_msgTypes[45]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2874,16 +3039,32 @@ var file_proto_eth_v1_beacon_chain_proto_rawDesc = []byte{
 	0x18, 0x0b, 0x20, 0x01, 0x28, 0x0c, 0x42, 0x06, 0x8a, 0xb5, 0x18, 0x02, 0x33, 0x32, 0x52, 0x10,
 	0x65, 0x78, 0x65, 0x63, 0x75, 0x74, 0x69, 0x6f, 0x6e, 0x50, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64,
 	0x12, 0x1c, 0x0a, 0x09, 0x74, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x18, 0x0c, 0x20,
-	0x01, 0x28, 0x04, 0x52, 0x09, 0x74, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x42, 0x7d,
-	0x0a, 0x13, 0x6f, 0x72, 0x67, 0x2e, 0x65, 0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d, 0x2e, 0x65,
-	0x74, 0x68, 0x2e, 0x76, 0x31, 0x42, 0x10, 0x42, 0x65, 0x61, 0x63, 0x6f, 0x6e, 0x43, 0x68, 0x61,
-	0x69, 0x6e, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a, 0x2e, 0x67, 0x69, 0x74, 0x68, 0x75,
-	0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x70, 0x72, 0x79, 0x73, 0x6d, 0x61, 0x74, 0x69, 0x63, 0x6c,
-	0x61, 0x62, 0x73, 0x2f, 0x70, 0x72, 0x79, 0x73, 0x6d, 0x2f, 0x76, 0x33, 0x2f, 0x70, 0x72, 0x6f,
-	0x74, 0x6f, 0x2f, 0x65, 0x74, 0x68, 0x2f, 0x76, 0x31, 0xaa, 0x02, 0x0f, 0x45, 0x74, 0x68, 0x65,
-	0x72, 0x65, 0x75, 0x6d, 0x2e, 0x45, 0x74, 0x68, 0x2e, 0x56, 0x31, 0xca, 0x02, 0x0f, 0x45, 0x74,
-	0x68, 0x65, 0x72, 0x65, 0x75, 0x6d, 0x5c, 0x45, 0x74, 0x68, 0x5c, 0x76, 0x31, 0x62, 0x06, 0x70,
-	0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x01, 0x28, 0x04, 0x52, 0x09, 0x74, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x22, 0x29,
+	0x0a, 0x0c, 0x42, 0x6c, 0x6f, 0x62, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x19,
+	0x0a, 0x08, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0c,
+	0x52, 0x07, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x49, 0x64, 0x22, 0x1a, 0x0a, 0x04, 0x42, 0x6c, 0x6f,
+	0x62, 0x12, 0x12, 0x0a, 0x04, 0x64, 0x61, 0x74, 0x61, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0c, 0x52,
+	0x04, 0x64, 0x61, 0x74, 0x61, 0x22, 0xbf, 0x01, 0x0a, 0x0d, 0x42, 0x6c, 0x6f, 0x62, 0x73, 0x52,
+	0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x2a, 0x0a, 0x11, 0x62, 0x65, 0x61, 0x63, 0x6f,
+	0x6e, 0x5f, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x5f, 0x72, 0x6f, 0x6f, 0x74, 0x18, 0x01, 0x20, 0x01,
+	0x28, 0x0c, 0x52, 0x0f, 0x62, 0x65, 0x61, 0x63, 0x6f, 0x6e, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x52,
+	0x6f, 0x6f, 0x74, 0x12, 0x2a, 0x0a, 0x11, 0x62, 0x65, 0x61, 0x63, 0x6f, 0x6e, 0x5f, 0x62, 0x6c,
+	0x6f, 0x63, 0x6b, 0x5f, 0x73, 0x6c, 0x6f, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x04, 0x52, 0x0f,
+	0x62, 0x65, 0x61, 0x63, 0x6f, 0x6e, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x53, 0x6c, 0x6f, 0x74, 0x12,
+	0x2b, 0x0a, 0x05, 0x62, 0x6c, 0x6f, 0x62, 0x73, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x15,
+	0x2e, 0x65, 0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d, 0x2e, 0x65, 0x74, 0x68, 0x2e, 0x76, 0x31,
+	0x2e, 0x42, 0x6c, 0x6f, 0x62, 0x52, 0x05, 0x62, 0x6c, 0x6f, 0x62, 0x73, 0x12, 0x29, 0x0a, 0x10,
+	0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x70, 0x72, 0x6f, 0x6f, 0x66,
+	0x18, 0x04, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x0f, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74,
+	0x65, 0x64, 0x50, 0x72, 0x6f, 0x6f, 0x66, 0x42, 0x7d, 0x0a, 0x13, 0x6f, 0x72, 0x67, 0x2e, 0x65,
+	0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d, 0x2e, 0x65, 0x74, 0x68, 0x2e, 0x76, 0x31, 0x42, 0x10,
+	0x42, 0x65, 0x61, 0x63, 0x6f, 0x6e, 0x43, 0x68, 0x61, 0x69, 0x6e, 0x50, 0x72, 0x6f, 0x74, 0x6f,
+	0x50, 0x01, 0x5a, 0x2e, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x70,
+	0x72, 0x79, 0x73, 0x6d, 0x61, 0x74, 0x69, 0x63, 0x6c, 0x61, 0x62, 0x73, 0x2f, 0x70, 0x72, 0x79,
+	0x73, 0x6d, 0x2f, 0x76, 0x33, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x65, 0x74, 0x68, 0x2f,
+	0x76, 0x31, 0xaa, 0x02, 0x0f, 0x45, 0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d, 0x2e, 0x45, 0x74,
+	0x68, 0x2e, 0x56, 0x31, 0xca, 0x02, 0x0f, 0x45, 0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d, 0x5c,
+	0x45, 0x74, 0x68, 0x5c, 0x76, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -2898,7 +3079,7 @@ func file_proto_eth_v1_beacon_chain_proto_rawDescGZIP() []byte {
 	return file_proto_eth_v1_beacon_chain_proto_rawDescData
 }
 
-var file_proto_eth_v1_beacon_chain_proto_msgTypes = make([]protoimpl.MessageInfo, 44)
+var file_proto_eth_v1_beacon_chain_proto_msgTypes = make([]protoimpl.MessageInfo, 47)
 var file_proto_eth_v1_beacon_chain_proto_goTypes = []interface{}{
 	(*GenesisResponse)(nil),                                         // 0: ethereum.eth.v1.GenesisResponse
 	(*StateRequest)(nil),                                            // 1: ethereum.eth.v1.StateRequest
@@ -2940,66 +3121,70 @@ var file_proto_eth_v1_beacon_chain_proto_goTypes = []interface{}{
 	(*WeakSubjectivityData)(nil),                                    // 37: ethereum.eth.v1.WeakSubjectivityData
 	(*ForkChoiceResponse)(nil),                                      // 38: ethereum.eth.v1.ForkChoiceResponse
 	(*ForkChoiceNode)(nil),                                          // 39: ethereum.eth.v1.ForkChoiceNode
-	(*GenesisResponse_Genesis)(nil),                                 // 40: ethereum.eth.v1.GenesisResponse.Genesis
-	(*StateRootResponse_StateRoot)(nil),                             // 41: ethereum.eth.v1.StateRootResponse.StateRoot
-	(*StateFinalityCheckpointResponse_StateFinalityCheckpoint)(nil), // 42: ethereum.eth.v1.StateFinalityCheckpointResponse.StateFinalityCheckpoint
-	nil,                           // 43: ethereum.eth.v1.SpecResponse.DataEntry
-	(*Fork)(nil),                  // 44: ethereum.eth.v1.Fork
-	(ValidatorStatus)(0),          // 45: ethereum.eth.v1.ValidatorStatus
-	(*ValidatorContainer)(nil),    // 46: ethereum.eth.v1.ValidatorContainer
-	(*Committee)(nil),             // 47: ethereum.eth.v1.Committee
-	(*Attestation)(nil),           // 48: ethereum.eth.v1.Attestation
-	(*BeaconBlockHeader)(nil),     // 49: ethereum.eth.v1.BeaconBlockHeader
-	(*BeaconBlock)(nil),           // 50: ethereum.eth.v1.BeaconBlock
-	(*AttesterSlashing)(nil),      // 51: ethereum.eth.v1.AttesterSlashing
-	(*ProposerSlashing)(nil),      // 52: ethereum.eth.v1.ProposerSlashing
-	(*SignedVoluntaryExit)(nil),   // 53: ethereum.eth.v1.SignedVoluntaryExit
-	(*Checkpoint)(nil),            // 54: ethereum.eth.v1.Checkpoint
-	(*timestamppb.Timestamp)(nil), // 55: google.protobuf.Timestamp
+	(*BlobsRequest)(nil),                                            // 40: ethereum.eth.v1.BlobsRequest
+	(*Blob)(nil),                                                    // 41: ethereum.eth.v1.Blob
+	(*BlobsResponse)(nil),                                           // 42: ethereum.eth.v1.BlobsResponse
+	(*GenesisResponse_Genesis)(nil),                                 // 43: ethereum.eth.v1.GenesisResponse.Genesis
+	(*StateRootResponse_StateRoot)(nil),                             // 44: ethereum.eth.v1.StateRootResponse.StateRoot
+	(*StateFinalityCheckpointResponse_StateFinalityCheckpoint)(nil), // 45: ethereum.eth.v1.StateFinalityCheckpointResponse.StateFinalityCheckpoint
+	nil,                           // 46: ethereum.eth.v1.SpecResponse.DataEntry
+	(*Fork)(nil),                  // 47: ethereum.eth.v1.Fork
+	(ValidatorStatus)(0),          // 48: ethereum.eth.v1.ValidatorStatus
+	(*ValidatorContainer)(nil),    // 49: ethereum.eth.v1.ValidatorContainer
+	(*Committee)(nil),             // 50: ethereum.eth.v1.Committee
+	(*Attestation)(nil),           // 51: ethereum.eth.v1.Attestation
+	(*BeaconBlockHeader)(nil),     // 52: ethereum.eth.v1.BeaconBlockHeader
+	(*BeaconBlock)(nil),           // 53: ethereum.eth.v1.BeaconBlock
+	(*AttesterSlashing)(nil),      // 54: ethereum.eth.v1.AttesterSlashing
+	(*ProposerSlashing)(nil),      // 55: ethereum.eth.v1.ProposerSlashing
+	(*SignedVoluntaryExit)(nil),   // 56: ethereum.eth.v1.SignedVoluntaryExit
+	(*Checkpoint)(nil),            // 57: ethereum.eth.v1.Checkpoint
+	(*timestamppb.Timestamp)(nil), // 58: google.protobuf.Timestamp
 }
 var file_proto_eth_v1_beacon_chain_proto_depIdxs = []int32{
-	40, // 0: ethereum.eth.v1.GenesisResponse.data:type_name -> ethereum.eth.v1.GenesisResponse.Genesis
-	41, // 1: ethereum.eth.v1.StateRootResponse.data:type_name -> ethereum.eth.v1.StateRootResponse.StateRoot
-	44, // 2: ethereum.eth.v1.StateForkResponse.data:type_name -> ethereum.eth.v1.Fork
-	42, // 3: ethereum.eth.v1.StateFinalityCheckpointResponse.data:type_name -> ethereum.eth.v1.StateFinalityCheckpointResponse.StateFinalityCheckpoint
-	45, // 4: ethereum.eth.v1.StateValidatorsRequest.status:type_name -> ethereum.eth.v1.ValidatorStatus
-	46, // 5: ethereum.eth.v1.StateValidatorsResponse.data:type_name -> ethereum.eth.v1.ValidatorContainer
+	43, // 0: ethereum.eth.v1.GenesisResponse.data:type_name -> ethereum.eth.v1.GenesisResponse.Genesis
+	44, // 1: ethereum.eth.v1.StateRootResponse.data:type_name -> ethereum.eth.v1.StateRootResponse.StateRoot
+	47, // 2: ethereum.eth.v1.StateForkResponse.data:type_name -> ethereum.eth.v1.Fork
+	45, // 3: ethereum.eth.v1.StateFinalityCheckpointResponse.data:type_name -> ethereum.eth.v1.StateFinalityCheckpointResponse.StateFinalityCheckpoint
+	48, // 4: ethereum.eth.v1.StateValidatorsRequest.status:type_name -> ethereum.eth.v1.ValidatorStatus
+	49, // 5: ethereum.eth.v1.StateValidatorsResponse.data:type_name -> ethereum.eth.v1.ValidatorContainer
 	9,  // 6: ethereum.eth.v1.ValidatorBalancesResponse.data:type_name -> ethereum.eth.v1.ValidatorBalance
-	46, // 7: ethereum.eth.v1.StateValidatorResponse.data:type_name -> ethereum.eth.v1.ValidatorContainer
-	47, // 8: ethereum.eth.v1.StateCommitteesResponse.data:type_name -> ethereum.eth.v1.Committee
-	48, // 9: ethereum.eth.v1.BlockAttestationsResponse.data:type_name -> ethereum.eth.v1.Attestation
+	49, // 7: ethereum.eth.v1.StateValidatorResponse.data:type_name -> ethereum.eth.v1.ValidatorContainer
+	50, // 8: ethereum.eth.v1.StateCommitteesResponse.data:type_name -> ethereum.eth.v1.Committee
+	51, // 9: ethereum.eth.v1.BlockAttestationsResponse.data:type_name -> ethereum.eth.v1.Attestation
 	15, // 10: ethereum.eth.v1.BlockRootResponse.data:type_name -> ethereum.eth.v1.BlockRootContainer
 	21, // 11: ethereum.eth.v1.BlockHeadersResponse.data:type_name -> ethereum.eth.v1.BlockHeaderContainer
 	21, // 12: ethereum.eth.v1.BlockHeaderResponse.data:type_name -> ethereum.eth.v1.BlockHeaderContainer
 	22, // 13: ethereum.eth.v1.BlockHeaderContainer.header:type_name -> ethereum.eth.v1.BeaconBlockHeaderContainer
-	49, // 14: ethereum.eth.v1.BeaconBlockHeaderContainer.message:type_name -> ethereum.eth.v1.BeaconBlockHeader
+	52, // 14: ethereum.eth.v1.BeaconBlockHeaderContainer.message:type_name -> ethereum.eth.v1.BeaconBlockHeader
 	25, // 15: ethereum.eth.v1.BlockResponse.data:type_name -> ethereum.eth.v1.BeaconBlockContainer
-	50, // 16: ethereum.eth.v1.BeaconBlockContainer.message:type_name -> ethereum.eth.v1.BeaconBlock
-	48, // 17: ethereum.eth.v1.SubmitAttestationsRequest.data:type_name -> ethereum.eth.v1.Attestation
-	48, // 18: ethereum.eth.v1.AttestationsPoolResponse.data:type_name -> ethereum.eth.v1.Attestation
-	51, // 19: ethereum.eth.v1.AttesterSlashingsPoolResponse.data:type_name -> ethereum.eth.v1.AttesterSlashing
-	52, // 20: ethereum.eth.v1.ProposerSlashingPoolResponse.data:type_name -> ethereum.eth.v1.ProposerSlashing
-	53, // 21: ethereum.eth.v1.VoluntaryExitsPoolResponse.data:type_name -> ethereum.eth.v1.SignedVoluntaryExit
-	44, // 22: ethereum.eth.v1.ForkScheduleResponse.data:type_name -> ethereum.eth.v1.Fork
-	43, // 23: ethereum.eth.v1.SpecResponse.data:type_name -> ethereum.eth.v1.SpecResponse.DataEntry
+	53, // 16: ethereum.eth.v1.BeaconBlockContainer.message:type_name -> ethereum.eth.v1.BeaconBlock
+	51, // 17: ethereum.eth.v1.SubmitAttestationsRequest.data:type_name -> ethereum.eth.v1.Attestation
+	51, // 18: ethereum.eth.v1.AttestationsPoolResponse.data:type_name -> ethereum.eth.v1.Attestation
+	54, // 19: ethereum.eth.v1.AttesterSlashingsPoolResponse.data:type_name -> ethereum.eth.v1.AttesterSlashing
+	55, // 20: ethereum.eth.v1.ProposerSlashingPoolResponse.data:type_name -> ethereum.eth.v1.ProposerSlashing
+	56, // 21: ethereum.eth.v1.VoluntaryExitsPoolResponse.data:type_name -> ethereum.eth.v1.SignedVoluntaryExit
+	47, // 22: ethereum.eth.v1.ForkScheduleResponse.data:type_name -> ethereum.eth.v1.Fork
+	46, // 23: ethereum.eth.v1.SpecResponse.data:type_name -> ethereum.eth.v1.SpecResponse.DataEntry
 	35, // 24: ethereum.eth.v1.DepositContractResponse.data:type_name -> ethereum.eth.v1.DepositContract
 	37, // 25: ethereum.eth.v1.WeakSubjectivityResponse.data:type_name -> ethereum.eth.v1.WeakSubjectivityData
-	54, // 26: ethereum.eth.v1.WeakSubjectivityData.ws_checkpoint:type_name -> ethereum.eth.v1.Checkpoint
-	54, // 27: ethereum.eth.v1.ForkChoiceResponse.justified_checkpoint:type_name -> ethereum.eth.v1.Checkpoint
-	54, // 28: ethereum.eth.v1.ForkChoiceResponse.finalized_checkpoint:type_name -> ethereum.eth.v1.Checkpoint
-	54, // 29: ethereum.eth.v1.ForkChoiceResponse.best_justified_checkpoint:type_name -> ethereum.eth.v1.Checkpoint
-	54, // 30: ethereum.eth.v1.ForkChoiceResponse.unrealized_justified_checkpoint:type_name -> ethereum.eth.v1.Checkpoint
-	54, // 31: ethereum.eth.v1.ForkChoiceResponse.unrealized_finalized_checkpoint:type_name -> ethereum.eth.v1.Checkpoint
+	57, // 26: ethereum.eth.v1.WeakSubjectivityData.ws_checkpoint:type_name -> ethereum.eth.v1.Checkpoint
+	57, // 27: ethereum.eth.v1.ForkChoiceResponse.justified_checkpoint:type_name -> ethereum.eth.v1.Checkpoint
+	57, // 28: ethereum.eth.v1.ForkChoiceResponse.finalized_checkpoint:type_name -> ethereum.eth.v1.Checkpoint
+	57, // 29: ethereum.eth.v1.ForkChoiceResponse.best_justified_checkpoint:type_name -> ethereum.eth.v1.Checkpoint
+	57, // 30: ethereum.eth.v1.ForkChoiceResponse.unrealized_justified_checkpoint:type_name -> ethereum.eth.v1.Checkpoint
+	57, // 31: ethereum.eth.v1.ForkChoiceResponse.unrealized_finalized_checkpoint:type_name -> ethereum.eth.v1.Checkpoint
 	39, // 32: ethereum.eth.v1.ForkChoiceResponse.forkchoice_nodes:type_name -> ethereum.eth.v1.ForkChoiceNode
-	55, // 33: ethereum.eth.v1.GenesisResponse.Genesis.genesis_time:type_name -> google.protobuf.Timestamp
-	54, // 34: ethereum.eth.v1.StateFinalityCheckpointResponse.StateFinalityCheckpoint.previous_justified:type_name -> ethereum.eth.v1.Checkpoint
-	54, // 35: ethereum.eth.v1.StateFinalityCheckpointResponse.StateFinalityCheckpoint.current_justified:type_name -> ethereum.eth.v1.Checkpoint
-	54, // 36: ethereum.eth.v1.StateFinalityCheckpointResponse.StateFinalityCheckpoint.finalized:type_name -> ethereum.eth.v1.Checkpoint
-	37, // [37:37] is the sub-list for method output_type
-	37, // [37:37] is the sub-list for method input_type
-	37, // [37:37] is the sub-list for extension type_name
-	37, // [37:37] is the sub-list for extension extendee
-	0,  // [0:37] is the sub-list for field type_name
+	41, // 33: ethereum.eth.v1.BlobsResponse.blobs:type_name -> ethereum.eth.v1.Blob
+	58, // 34: ethereum.eth.v1.GenesisResponse.Genesis.genesis_time:type_name -> google.protobuf.Timestamp
+	57, // 35: ethereum.eth.v1.StateFinalityCheckpointResponse.StateFinalityCheckpoint.previous_justified:type_name -> ethereum.eth.v1.Checkpoint
+	57, // 36: ethereum.eth.v1.StateFinalityCheckpointResponse.StateFinalityCheckpoint.current_justified:type_name -> ethereum.eth.v1.Checkpoint
+	57, // 37: ethereum.eth.v1.StateFinalityCheckpointResponse.StateFinalityCheckpoint.finalized:type_name -> ethereum.eth.v1.Checkpoint
+	38, // [38:38] is the sub-list for method output_type
+	38, // [38:38] is the sub-list for method input_type
+	38, // [38:38] is the sub-list for extension type_name
+	38, // [38:38] is the sub-list for extension extendee
+	0,  // [0:38] is the sub-list for field type_name
 }
 
 func init() { file_proto_eth_v1_beacon_chain_proto_init() }
@@ -3493,7 +3678,7 @@ func file_proto_eth_v1_beacon_chain_proto_init() {
 			}
 		}
 		file_proto_eth_v1_beacon_chain_proto_msgTypes[40].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*GenesisResponse_Genesis); i {
+			switch v := v.(*BlobsRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -3505,7 +3690,7 @@ func file_proto_eth_v1_beacon_chain_proto_init() {
 			}
 		}
 		file_proto_eth_v1_beacon_chain_proto_msgTypes[41].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*StateRootResponse_StateRoot); i {
+			switch v := v.(*Blob); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -3517,6 +3702,42 @@ func file_proto_eth_v1_beacon_chain_proto_init() {
 			}
 		}
 		file_proto_eth_v1_beacon_chain_proto_msgTypes[42].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*BlobsResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_proto_eth_v1_beacon_chain_proto_msgTypes[43].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*GenesisResponse_Genesis); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_proto_eth_v1_beacon_chain_proto_msgTypes[44].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*StateRootResponse_StateRoot); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_proto_eth_v1_beacon_chain_proto_msgTypes[45].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*StateFinalityCheckpointResponse_StateFinalityCheckpoint); i {
 			case 0:
 				return &v.state
@@ -3538,7 +3759,7 @@ func file_proto_eth_v1_beacon_chain_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_proto_eth_v1_beacon_chain_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   44,
+			NumMessages:   47,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/eth/v1/beacon_chain.proto
+++ b/proto/eth/v1/beacon_chain.proto
@@ -339,3 +339,20 @@ message ForkChoiceNode {
     // Timestamp when the node was inserted
     uint64 timestamp = 12;
 }
+
+message BlobsRequest {
+    // The block identifier. Can be one of: "head" (canonical head in node's view), "genesis",
+    // "finalized", <slot>, <hex encoded blockRoot with 0x prefix>.
+    bytes block_id = 1;
+}
+
+message Blob {
+    bytes data = 1;
+}
+
+message BlobsResponse {
+    bytes beacon_block_root = 1;
+    uint64 beacon_block_slot = 2;
+    repeated Blob blobs = 3;
+    bytes aggregated_proof = 4;
+}


### PR DESCRIPTION
Rebased #16 on the `eip-4844` branch.

> This PR:
> 
> - Fixes some bazel issues; fix missing imports in bazel build files, and disabled some linting warnings in the sync package that stopped it from compiling.
> - Define api protobuf types for serving blobs sidecar data, and update protobuf code (using the `./hack/update-go-pbs.sh` script)
> - Implements a basic API to retrieve a blobs sidecar by beacon block root, slot or label.
> - Implements the http gateway hacks to get the new grpc api endpoint also exposed in http api
>
> Very experimental, didn't get to testing yet.
> 
> API endpoint: `/eth/v1/blobs/sidecar/{block_id}`